### PR TITLE
Add ExecuteSubsystemAsync for subsystem based proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ class SshClient : IDisposable
   Task<RemoteProcess> ExecuteAsync(string command, CancellationToken cancellationToken);
   Task<RemoteProcess> ExecuteAsync(string command, ExecuteOptions? options = null, CancellationToken cancellationToken = default);
 
+  Task<RemoteProcess> ExecuteSubsystemAsync(string subsystem, CancellationToken cancellationToken);
+  Task<RemoteProcess> ExecuteSubsystemAsync(string subsystem, ExecuteOptions? options = null, CancellationToken cancellationToken = default);
+
   Task<SshDataStream> OpenTcpConnectionAsync(string host, int port, CancellationToken cancellationToken = default);
   Task<SshDataStream> OpenUnixConnectionAsync(string path, CancellationToken cancellationToken = default);
 

--- a/src/Tmds.Ssh/ISshClientImplementation.cs
+++ b/src/Tmds.Ssh/ISshClientImplementation.cs
@@ -11,6 +11,7 @@ interface ISshClientImplementation
 {
     Task ConnectAsync(CancellationToken cancellationToken);
     Task<ISshChannel> OpenRemoteProcessChannelAsync(Type channelType, string command, CancellationToken cancellationToken);
+    Task<ISshChannel> OpenRemoteSubsystemChannelAsync(Type channelType, string subsystem, CancellationToken cancellationToken);
     Task<ISshChannel> OpenTcpConnectionChannelAsync(Type channelType, string host, int port, CancellationToken cancellationToken);
     Task<ISshChannel> OpenUnixConnectionChannelAsync(Type channelType, string path, CancellationToken cancellationToken);
     Task<ISshChannel> OpenSftpClientChannelAsync(Action<SshChannel> onAbort, CancellationToken cancellationToken);

--- a/src/Tmds.Ssh/SshClient.cs
+++ b/src/Tmds.Ssh/SshClient.cs
@@ -182,6 +182,23 @@ public sealed partial class SshClient : IDisposable
             standardOutputEncoding);
     }
 
+    public Task<RemoteProcess> ExecuteSubsystemAsync(string subsystem, CancellationToken cancellationToken)
+        => ExecuteSubsystemAsync(subsystem, null, cancellationToken);
+
+    public async Task<RemoteProcess> ExecuteSubsystemAsync(string subsystem, ExecuteOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        SshSession session = await GetSessionAsync(cancellationToken).ConfigureAwait(false);
+        var channel = await session.OpenRemoteSubsystemChannelAsync(typeof(RemoteProcess), subsystem, cancellationToken).ConfigureAwait(false);
+
+        Encoding standardInputEncoding = options?.StandardInputEncoding ?? ExecuteOptions.DefaultEncoding;
+        Encoding standardErrorEncoding = options?.StandardErrorEncoding ?? ExecuteOptions.DefaultEncoding;
+        Encoding standardOutputEncoding = options?.StandardOutputEncoding ?? ExecuteOptions.DefaultEncoding;
+        return new RemoteProcess(channel,
+            standardInputEncoding,
+            standardErrorEncoding,
+            standardOutputEncoding);
+    }
+
     public async Task<SshDataStream> OpenTcpConnectionAsync(string host, int port, CancellationToken cancellationToken = default)
     {
         SshSession session = await GetSessionAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Tmds.Ssh/SshSession.cs
+++ b/src/Tmds.Ssh/SshSession.cs
@@ -623,7 +623,7 @@ sealed partial class SshSession : ISshClientImplementation
     }
 
     public async Task<ISshChannel> OpenSftpClientChannelAsync(Action<SshChannel> onAbort, CancellationToken cancellationToken)
-        => await OpenSubsystemChannelAsync(typeof(SftpChannel), onAbort, "sft", cancellationToken).ConfigureAwait(false);
+        => await OpenSubsystemChannelAsync(typeof(SftpChannel), onAbort, "sftp", cancellationToken).ConfigureAwait(false);
 
     private async Task<ISshChannel> OpenSubsystemChannelAsync(Type channelType, Action<SshChannel>? onAbort, string subsystem, CancellationToken cancellationToken)
     {

--- a/src/Tmds.Ssh/SshSession.cs
+++ b/src/Tmds.Ssh/SshSession.cs
@@ -583,6 +583,9 @@ sealed partial class SshSession : ISshClientImplementation
         }
     }
 
+    public async Task<ISshChannel> OpenRemoteSubsystemChannelAsync(Type channelType, string subsystem, CancellationToken cancellationToken)
+        => await OpenSubsystemChannelAsync(channelType, null, subsystem, cancellationToken).ConfigureAwait(false);
+
     public async Task<ISshChannel> OpenTcpConnectionChannelAsync(Type channelType, string host, int port, CancellationToken cancellationToken)
     {
         SshChannel channel = CreateChannel(channelType);
@@ -620,8 +623,11 @@ sealed partial class SshSession : ISshClientImplementation
     }
 
     public async Task<ISshChannel> OpenSftpClientChannelAsync(Action<SshChannel> onAbort, CancellationToken cancellationToken)
+        => await OpenSubsystemChannelAsync(typeof(SftpChannel), onAbort, "sft", cancellationToken).ConfigureAwait(false);
+
+    private async Task<ISshChannel> OpenSubsystemChannelAsync(Type channelType, Action<SshChannel>? onAbort, string subsystem, CancellationToken cancellationToken)
     {
-        SshChannel channel = CreateChannel(typeof(SftpClient), onAbort);
+        SshChannel channel = CreateChannel(channelType, onAbort);
         try
         {
             // Open the session channel.
@@ -632,8 +638,8 @@ sealed partial class SshSession : ISshClientImplementation
 
             // Request subsystem execution.
             {
-                channel.TrySendExecSubsystemMessage("sftp");
-                await channel.ReceiveChannelRequestSuccessAsync("Failed to execute sftp subsystem.", cancellationToken).ConfigureAwait(false);
+                channel.TrySendExecSubsystemMessage(subsystem);
+                await channel.ReceiveChannelRequestSuccessAsync($"Failed to execute {subsystem} subsystem.", cancellationToken).ConfigureAwait(false);
             }
 
             return channel;

--- a/test/Tmds.Ssh.Tests/RemoteProcessTests.cs
+++ b/test/Tmds.Ssh.Tests/RemoteProcessTests.cs
@@ -45,6 +45,36 @@ public class RemoteProcess
     }
 
     [Fact]
+    public async Task SubsystemProcess()
+    {
+        using var client = await _sshServer.CreateClientAsync();
+        byte[] helloWorld1Bytes = Encoding.UTF8.GetBytes("hello world 1");
+        byte[] helloWorld2Bytes = Encoding.UTF8.GetBytes("hello world 2");
+        using var process = await client.ExecuteSubsystemAsync(_sshServer.TestSubsystem);
+
+        await process.WriteLineAsync("echo -n 'hello world 1'");
+
+        byte[] buffer = new byte[512];
+        (bool isError, int bytesRead) = await process.ReadAsync(buffer, buffer);
+        Assert.False(isError);
+        Assert.Equal(helloWorld1Bytes, buffer.AsSpan(0, bytesRead).ToArray());
+
+        await process.WriteLineAsync("echo -n 'hello world 2'");
+
+        (isError, bytesRead) = await process.ReadAsync(buffer, buffer);
+        Assert.False(isError);
+        Assert.Equal(helloWorld2Bytes, buffer.AsSpan(0, bytesRead).ToArray());
+
+        await process.WriteLineAsync("exit 1");
+
+        (isError, bytesRead) = await process.ReadAsync(buffer, buffer);
+        Assert.False(isError);
+        Assert.Equal(0, bytesRead);
+
+        Assert.Equal(1, process.ExitCode);
+    }
+
+    [Fact]
     public async Task ExitCodeThrowsInvalidOperationExceptionWhenProcessNotExited()
     {
         using var client = await _sshServer.CreateClientAsync();

--- a/test/Tmds.Ssh.Tests/SshServer.cs
+++ b/test/Tmds.Ssh.Tests/SshServer.cs
@@ -20,7 +20,7 @@ public class SshServer : IDisposable
     public string TestUserHome => $"/home/{TestUser}";
     public string TestUserPassword => "secret";
     public string TestUserIdentityFile => $"{ContainerBuildContext}/user_key_rsa";
-    public string TestSubsystem = "tmds_test";
+    public string TestSubsystem = "test_subsystem";
     public string ServerHost => _host;
     public int ServerPort => _port;
     public string KnownHostsFilePath => _knownHostsFile;

--- a/test/Tmds.Ssh.Tests/SshServer.cs
+++ b/test/Tmds.Ssh.Tests/SshServer.cs
@@ -20,6 +20,7 @@ public class SshServer : IDisposable
     public string TestUserHome => $"/home/{TestUser}";
     public string TestUserPassword => "secret";
     public string TestUserIdentityFile => $"{ContainerBuildContext}/user_key_rsa";
+    public string TestSubsystem = "tmds_test";
     public string ServerHost => _host;
     public int ServerPort => _port;
     public string KnownHostsFilePath => _knownHostsFile;

--- a/test/Tmds.Ssh.Tests/sshd_container/Dockerfile
+++ b/test/Tmds.Ssh.Tests/sshd_container/Dockerfile
@@ -8,6 +8,9 @@ RUN dnf install -y openssh-server passwd socat dos2unix && \
 RUN useradd -ms /bin/bash testuser
 RUN echo 'secret' | passwd --stdin testuser
 
+# Add test subsystem configuration
+RUN echo 'Subsystem tmds_test /usr/bin/sh' >> /etc/ssh/sshd_config
+
 # Add server keys.
 COPY server_key_rsa /etc/ssh/ssh_host_rsa_key
 COPY server_key_ecdsa /etc/ssh/ssh_host_ecdsa_key

--- a/test/Tmds.Ssh.Tests/sshd_container/Dockerfile
+++ b/test/Tmds.Ssh.Tests/sshd_container/Dockerfile
@@ -9,7 +9,7 @@ RUN useradd -ms /bin/bash testuser
 RUN echo 'secret' | passwd --stdin testuser
 
 # Add test subsystem configuration
-RUN echo 'Subsystem tmds_test /usr/bin/sh' >> /etc/ssh/sshd_config
+RUN echo 'Subsystem test_subsystem /usr/bin/sh' >> /etc/ssh/sshd_config
 
 # Add server keys.
 COPY server_key_rsa /etc/ssh/ssh_host_rsa_key


### PR DESCRIPTION
Adds the ExecuteSubsystemAsync call which can create an SSH channel from a subsystem and return the RemoteProcess interface. This is used when the SSH server defines custom subsystems in its sshd_config file that allows a client to create a channel using a pre-defined subsystem name rather than through an explicit command line argument.

Fixes: https://github.com/tmds/Tmds.Ssh/issues/182