### PR TITLE
SshClientSettings: support parsing usernames that include a realm.

### DIFF
--- a/src/Tmds.Ssh/SshClientSettings.cs
+++ b/src/Tmds.Ssh/SshClientSettings.cs
@@ -32,13 +32,13 @@ public sealed partial class SshClientSettings
     {
         string host = destination;
         int port = 22;
-        int colonPos = host.IndexOf(":");
+        int colonPos = host.LastIndexOf(":");
         if (colonPos != -1)
         {
             port = int.Parse(host.Substring(colonPos + 1));
             host = host.Substring(0, colonPos);
         }
-        int atPos = host.IndexOf("@");
+        int atPos = host.LastIndexOf("@");
         string username;
         if (atPos != -1)
         {

--- a/test/Tmds.Ssh.Tests/SshClientSettingsTests.cs
+++ b/test/Tmds.Ssh.Tests/SshClientSettingsTests.cs
@@ -20,6 +20,25 @@ public class ClientSettingsTests
         Assert.Null(settings.HostAuthentication);
     }
 
+    [Theory]
+    [InlineData("", null, "", 22)]
+    [InlineData("host.com", null, "host.com", 22)]
+    [InlineData("user@host.com", "user", "host.com", 22)]
+    [InlineData("host.com:5000", null, "host.com", 5000)]
+    [InlineData("user@host.com:5000", "user", "host.com", 5000)]
+    [InlineData("user@realm@host.com", "user@realm", "host.com", 22)]
+    [InlineData("user@realm@host.com:5000", "user@realm", "host.com", 5000)]
+    public void Parse(string destination, string? expectedUsername, string expectedHost, int expectedPort)
+    {
+        expectedUsername ??= Environment.UserName;
+
+        var settings = new SshClientSettings(destination);
+
+        Assert.Equal(expectedHost, settings.Host);
+        Assert.Equal(expectedUsername, settings.UserName);
+        Assert.Equal(expectedPort, settings.Port);
+    }
+
     private static string DefaultKnownHostsFile
         => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.DoNotVerify),
                         ".ssh",


### PR DESCRIPTION
Fixes https://github.com/tmds/Tmds.Ssh/issues/189.

@jborean93 ptal.