### PR TITLE
Support using private keys that are not stored in files.

### DIFF
--- a/src/Tmds.Ssh/PrivateKeyCredential.cs
+++ b/src/Tmds.Ssh/PrivateKeyCredential.cs
@@ -1,20 +1,94 @@
 // This file is part of Tmds.Ssh which is released under MIT.
 // See file LICENSE for full license details.
 
+using System.Security.Cryptography;
+
 namespace Tmds.Ssh;
 
-public sealed class PrivateKeyCredential : Credential
+public class PrivateKeyCredential : Credential
 {
-    internal string FilePath { get; }
+    internal string Identifier { get; }
 
-    internal Func<string?> PasswordPrompt { get; }
+    private Func<CancellationToken, ValueTask<Key>> LoadKey { get; }
 
-    public PrivateKeyCredential(string path, string? password = null) : this(path, () => password)
+    public PrivateKeyCredential(string path, string? password = null, string? identifier = null) :
+        this(path, () => password, identifier)
     { }
 
-    public PrivateKeyCredential(string path, Func<string?> passwordPrompt)
+    public PrivateKeyCredential(string path, Func<string?> passwordPrompt, string? identifier = null) :
+        this(LoadKeyFromFile(path ?? throw new ArgumentNullException(nameof(path)), passwordPrompt), identifier ?? path)
+    { }
+
+    // Allows the user to implement derived classes that represent a private key.
+    protected PrivateKeyCredential(Func<CancellationToken, ValueTask<Key>> loadKey, string identifier)
     {
-        FilePath = path ?? throw new ArgumentNullException(nameof(path));
-        PasswordPrompt = passwordPrompt;
+        LoadKey = loadKey;
+        Identifier = identifier;
+    }
+
+    private static Func<CancellationToken, ValueTask<Key>> LoadKeyFromFile(string path, Func<string?> passwordPrompt)
+        => (CancellationToken cancellationToken) =>
+        {
+            if (PrivateKeyParser.TryParsePrivateKeyFile(path, passwordPrompt, out PrivateKey? privateKey, out Exception? error))
+            {
+                return ValueTask.FromResult(new Key(privateKey));
+            }
+
+            if (error is FileNotFoundException or DirectoryNotFoundException)
+            {
+                return ValueTask.FromResult(default(Key));
+            }
+
+            throw error;
+        };
+
+    // This is a type we expose to our derive types to avoid having to expose PrivateKey and a bunch of other internals.
+    protected readonly struct Key
+    {
+        internal PrivateKey? PrivateKey { get; }
+
+        public Key(RSA rsa)
+        {
+            PrivateKey = new RsaPrivateKey(rsa);
+        }
+
+        public Key(ECDsa ecdsa)
+        {
+            ECParameters parameters = ecdsa.ExportParameters(includePrivateParameters: false);
+            Oid oid = parameters.Curve.Oid;
+
+            Name algorithm;
+            Name curveName;
+            HashAlgorithmName hashAlgorithm;
+            if (oid.Equals(ECCurve.NamedCurves.nistP256.Oid))
+            {
+                (algorithm, curveName, hashAlgorithm) = (AlgorithmNames.EcdsaSha2Nistp256, AlgorithmNames.Nistp256, HashAlgorithmName.SHA256);
+            }
+            else if (oid.Equals(ECCurve.NamedCurves.nistP384.Oid))
+            {
+                (algorithm, curveName, hashAlgorithm) = (AlgorithmNames.EcdsaSha2Nistp384, AlgorithmNames.Nistp384, HashAlgorithmName.SHA384);
+            }
+            else if (oid.Equals(ECCurve.NamedCurves.nistP521.Oid))
+            {
+                (algorithm, curveName, hashAlgorithm) = (AlgorithmNames.EcdsaSha2Nistp521, AlgorithmNames.Nistp521, HashAlgorithmName.SHA512);
+            }
+            else
+            {
+                throw new NotSupportedException($"Curve {oid} is not known.");
+            }
+
+            PrivateKey = new ECDsaPrivateKey(ecdsa, algorithm, curveName, hashAlgorithm);
+        }
+
+        internal Key(PrivateKey key)
+        {
+            PrivateKey = key;
+        }
+    }
+
+    internal async ValueTask<PrivateKey?> LoadKeyAsync(CancellationToken cancellationToken)
+    {
+        Key key = await LoadKey(cancellationToken);
+        return key.PrivateKey;
     }
 }

--- a/src/Tmds.Ssh/SshClientLogger.cs
+++ b/src/Tmds.Ssh/SshClientLogger.cs
@@ -193,8 +193,8 @@ static partial class SshClientLogger
     [LoggerMessage(
         EventId = 19,
         Level = LogLevel.Information,
-        Message = "Auth using publickey from '{FileName}' with {SignatureAlgorithm} signature")]
-    public static partial void PublicKeyAuth(this ILogger<SshClient> logger, string fileName, Name signatureAlgorithm);
+        Message = "Auth using publickey '{keyIdentifier}' with {SignatureAlgorithm} signature")]
+    public static partial void PublicKeyAuth(this ILogger<SshClient> logger, string keyIdentifier, Name signatureAlgorithm);
 
     [LoggerMessage(
         EventId = 20,
@@ -211,20 +211,20 @@ static partial class SshClientLogger
     [LoggerMessage(
         EventId = 22,
         Level = LogLevel.Information,
-        Message = "Public key file '{FileName}' not found.")]
-    public static partial void PublicKeyFileNotFound(this ILogger<SshClient> logger, string fileName);
+        Message = "Public key '{KeyIdentifier}' not found.")]
+    public static partial void PublicKeyFileNotFound(this ILogger<SshClient> logger, string keyIdentifier);
 
     [LoggerMessage(
         EventId = 23,
         Level = LogLevel.Error,
-        Message = "Failed to load public key file '{FileName}'.")]
-    public static partial void PublicKeyCanNotLoad(this ILogger<SshClient> logger, string fileName, Exception exception);
+        Message = "Failed to load public key '{KeyIdentifier}'.")]
+    public static partial void PublicKeyCanNotLoad(this ILogger<SshClient> logger, string keyIdentifier, Exception exception);
 
     [LoggerMessage(
         EventId = 24,
         Level = LogLevel.Information,
-        Message = "Public key file '{FileName}' has no accepted algorithms. Accepted algorithms: {AcceptedAlgorithms}")]
-    public static partial void PublicKeyAlgorithmsNotAccepted(this ILogger<SshClient> logger, string fileName, List<Name> acceptedAlgorithms);
+        Message = "Public key '{KeyIdentifier}' has no accepted algorithms. Accepted algorithms: {AcceptedAlgorithms}")]
+    public static partial void PublicKeyAlgorithmsNotAccepted(this ILogger<SshClient> logger, string keyIdentifier, List<Name> acceptedAlgorithms);
 
     [LoggerMessage(
         EventId = 25,


### PR DESCRIPTION
This enables the key store use-case described in https://github.com/tmds/Tmds.Ssh/issues/205#issuecomment-2295601168.

This adds support for implementing such keys by deriving from `PrivateKeyCredential`.

We re-use the BCL `RSA` and `ECDsa` classes as abstractions for the key operations.

The implementation can be enhanced latter on by introducing our own abstractions for the key types. This would enable async key operations, and supporting key types the BCL has no abstraction for (like ED25519).

@jborean93 ptal.