### PR TITLE
Support decoding private keys that use the chacha20-poly1305@openssh.com cipher.

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ Supported private key encryption cyphers:
 - OpenSSH Keys `OPENSSH PRIVATE KEY` (`openssh-key-v1`)
   - aes[128|192|256]-[cbc|ctr]
   - aes[128|256]-gcm@openssh.com
+  - chacha20-poly1305@openssh.com
 
 Supported client key algorithms:
 - ssh-ed25519

--- a/src/Tmds.Ssh/AesCtr.cs
+++ b/src/Tmds.Ssh/AesCtr.cs
@@ -7,8 +7,11 @@ namespace Tmds.Ssh;
 
 static class AesCtr
 {
-    public static void DecryptCtr(ReadOnlySpan<byte> key, Span<byte> counter, ReadOnlySpan<byte> ciphertext, Span<byte> plaintext)
+    public static void DecryptCtr(ReadOnlySpan<byte> key, ReadOnlySpan<byte> iv, ReadOnlySpan<byte> ciphertext, Span<byte> plaintext)
     {
+        Span<byte> counter = stackalloc byte[iv.Length];
+        iv.CopyTo(counter);
+
         if (plaintext.Length < ciphertext.Length)
         {
             throw new ArgumentException("Plaintext buffer is too small.");

--- a/src/Tmds.Ssh/PacketEncryptionAlgorithm.cs
+++ b/src/Tmds.Ssh/PacketEncryptionAlgorithm.cs
@@ -16,7 +16,6 @@ sealed class PacketEncryptionAlgorithm
     {
         KeyLength = keyLength;
         IVLength = ivLength;
-        IsAuthenticated = isAuthenticated;
         TagLength = tagLength;
         _createPacketEncryptor = createPacketEncryptor;
         _createPacketDecryptor = createPacketDecryptor;
@@ -24,8 +23,8 @@ sealed class PacketEncryptionAlgorithm
 
     public int KeyLength { get; }
     public int IVLength { get; }
-    public bool IsAuthenticated { get; }
-    public int TagLength { get; } // When IsAuthenticated == true
+    public bool IsAuthenticated => TagLength > 0;
+    private int TagLength { get; }
 
     public IPacketEncryptor CreatePacketEncryptor(byte[] key, byte[] iv, HMacAlgorithm? hmacAlgorithm, byte[] hmacKey)
     {

--- a/test/Tmds.Ssh.Tests/PrivateKeyCredentialTests.cs
+++ b/test/Tmds.Ssh.Tests/PrivateKeyCredentialTests.cs
@@ -101,6 +101,7 @@ public class PrivateKeyCredentialTests
     [InlineData("aes256-ctr")]
     [InlineData("aes128-gcm@openssh.com")]
     [InlineData("aes256-gcm@openssh.com")]
+    [InlineData("chacha20-poly1305@openssh.com")]
     public async Task OpenSshRsaKey(string? cipher)
     {
         await RunWithKeyConversion(_sshServer.TestUserIdentityFile, async (string localKey) =>


### PR DESCRIPTION
Fixes https://github.com/tmds/Tmds.Ssh/issues/210.

cc @jborean93 