### PR TITLE
Add Azure Key example and fix ECDSA OID check

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,5 +12,8 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="Tmds.ExecFunction" Version="0.7.1" />
+    <!-- Example dependencies -->
+    <PackageVersion Include="Azure.Identity" Version="1.12.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ $ dotnet run
 hello world!
 ```
 
+## Examples
+
+The following are some example projects that show how Tmds.Ssh can be used:
+
+- [scp](./examples/scp) - SCP client to copy/fetch files
+- [ssh](./examples/ssh) - SSH client
+- [azure_key](./examples/azure_key) - SSH client with private keys stored in Azure Key Vault.
+
 ## API
 
 ```cs
@@ -500,14 +508,6 @@ Under these levels, the logged messages may include:
 - file paths (including those of private keys)
 
 The `Debug` and `Trace` loglevels should not be used in production. Under the `Trace` level all packets are logged. This will expose sensitive data related to the SSH connection and the application itself.
-
-## Examples
-
-The following are some example projects that show how Tmds.Ssh can be used:
-
-- [scp](./examples/scp) - SCP client to copy/fetch files
-- [ssh](./examples/ssh) - SSH client
-- [azure_key](./examples/azure_key) - SSH client with private keys stored in Azure Key Vault.
 
 ## CI Feed
 

--- a/README.md
+++ b/README.md
@@ -501,6 +501,14 @@ Under these levels, the logged messages may include:
 
 The `Debug` and `Trace` loglevels should not be used in production. Under the `Trace` level all packets are logged. This will expose sensitive data related to the SSH connection and the application itself.
 
+## Examples
+
+The following are some example projects that show how Tmds.Ssh can be used:
+
+- [scp](./examples/scp) - SCP client to copy/fetch files
+- [ssh](./examples/ssh) - SSH client
+- [azure_key](./examples/azure_key) - SSH client with private keys stored in Azure Key Vault.
+
 ## CI Feed
 
 You can obtain packages from the CI NuGet feed: https://www.myget.org/F/tmds/api/v3/index.json.

--- a/examples/azure_key/AzureECDsaKey.cs
+++ b/examples/azure_key/AzureECDsaKey.cs
@@ -1,0 +1,37 @@
+using Azure.Security.KeyVault.Keys.Cryptography;
+using System;
+using System.Security.Cryptography;
+using AzureSignatureAlgorithm = Azure.Security.KeyVault.Keys.Cryptography.SignatureAlgorithm;
+
+namespace Tmds.Ssh.AzureKeyExample;
+
+sealed class AzureECDsaKey : ECDsa
+{
+    private readonly CryptographyClient _cryptoClient;
+    private readonly ECParameters _publicParameters;
+    private readonly AzureSignatureAlgorithm _signatureAlgorithm;
+
+    public AzureECDsaKey(CryptographyClient client, ECParameters publicParameters, AzureSignatureAlgorithm signatureAlgorithm)
+    {
+        KeySizeValue = publicParameters.Q.X!.Length * 8;
+        _cryptoClient = client;
+        _publicParameters = publicParameters;
+        _signatureAlgorithm = signatureAlgorithm;
+    }
+
+    public override ECParameters ExportParameters(bool includePrivateParameters)
+    {
+        if (includePrivateParameters)
+        {
+            throw new CryptographicException("Cannot export private parameters");
+        }
+
+        return _publicParameters;
+    }
+
+    public override byte[] SignHash(byte[] hash)
+        => _cryptoClient.Sign(_signatureAlgorithm, hash).Signature;
+
+    public override bool VerifyHash(byte[] hash, byte[] signature)
+        => throw new NotImplementedException();
+}

--- a/examples/azure_key/AzureECDsaKey.cs
+++ b/examples/azure_key/AzureECDsaKey.cs
@@ -1,6 +1,7 @@
 using Azure.Security.KeyVault.Keys.Cryptography;
 using System;
 using System.Security.Cryptography;
+using System.Threading;
 using AzureSignatureAlgorithm = Azure.Security.KeyVault.Keys.Cryptography.SignatureAlgorithm;
 
 namespace Tmds.Ssh.AzureKeyExample;
@@ -10,13 +11,19 @@ sealed class AzureECDsaKey : ECDsa
     private readonly CryptographyClient _cryptoClient;
     private readonly ECParameters _publicParameters;
     private readonly AzureSignatureAlgorithm _signatureAlgorithm;
+    private readonly CancellationToken _cancellationToken;
 
-    public AzureECDsaKey(CryptographyClient client, ECParameters publicParameters, AzureSignatureAlgorithm signatureAlgorithm)
+    public AzureECDsaKey(
+        CryptographyClient client,
+        ECParameters publicParameters,
+        AzureSignatureAlgorithm signatureAlgorithm,
+        CancellationToken cancellationToken)
     {
         KeySizeValue = publicParameters.Q.X!.Length * 8;
         _cryptoClient = client;
         _publicParameters = publicParameters;
         _signatureAlgorithm = signatureAlgorithm;
+        _cancellationToken = cancellationToken;
     }
 
     public override ECParameters ExportParameters(bool includePrivateParameters)
@@ -30,7 +37,10 @@ sealed class AzureECDsaKey : ECDsa
     }
 
     public override byte[] SignHash(byte[] hash)
-        => _cryptoClient.Sign(_signatureAlgorithm, hash).Signature;
+        => _cryptoClient.SignAsync(
+            _signatureAlgorithm,
+            hash,
+            _cancellationToken).GetAwaiter().GetResult().Signature;
 
     public override bool VerifyHash(byte[] hash, byte[] signature)
         => throw new NotImplementedException();

--- a/examples/azure_key/AzureKeyCredential.cs
+++ b/examples/azure_key/AzureKeyCredential.cs
@@ -1,0 +1,137 @@
+using Azure.Core;
+using Azure.Identity;
+using Azure.Security.KeyVault.Keys;
+using Azure.Security.KeyVault.Keys.Cryptography;
+using System;
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AzureSignatureAlgorithm = Azure.Security.KeyVault.Keys.Cryptography.SignatureAlgorithm;
+
+namespace Tmds.Ssh.AzureKeyExample;
+
+sealed class AzureKeyCredential : PrivateKeyCredential
+{
+    public AzureKeyCredential(string vaultName, string keyName) :
+        base((c) => GetAzureKey(vaultName, keyName, c), $"Azure Key Vault: {vaultName}/{keyName}")
+    { }
+
+    public static async ValueTask<string> GetAzurePubKey(string vaultName, string keyName)
+    {
+        (var _, KeyVaultKey key) = await GetKeyVaultKey(vaultName, keyName);
+
+        if (key.KeyType == KeyType.Rsa)
+        {
+            RSAParameters pubParams = key.Key.ToRSA(includePrivateParameters: false)
+                .ExportParameters(false);
+            return GetRsaPubKey(pubParams);
+        }
+        else if (key.KeyType == KeyType.Ec)
+        {
+            ECParameters pubParams = key.Key.ToECDsa(includePrivateParameters: false)
+                .ExportParameters(false);
+            return GetEcdsaPubKey(pubParams);
+        }
+        else
+        {
+            throw new NotImplementedException($"Unsupported Azure key type {key.KeyType}");
+        }
+    }
+
+    private static async ValueTask<Key> GetAzureKey(string vaultName, string keyName, CancellationToken cancellationToken = default)
+    {
+        (TokenCredential cred, KeyVaultKey key) = await GetKeyVaultKey(vaultName, keyName);
+
+        if (key.KeyType == KeyType.Rsa)
+        {
+            CryptographyClient azureClient = new CryptographyClient(key.Id, cred);
+            RSAParameters pubParams = key.Key.ToRSA(includePrivateParameters: false)
+                .ExportParameters(false);
+
+            return new Key(new AzureRsaKey(azureClient, pubParams));
+        }
+        else if (key.KeyType == KeyType.Ec)
+        {
+            AzureSignatureAlgorithm sigAlgo = key.Key.CurveName.ToString() switch
+            {
+                "P-256" => AzureSignatureAlgorithm.ES256,
+                "P-384" => AzureSignatureAlgorithm.ES384,
+                "P-521" => AzureSignatureAlgorithm.ES512,
+                _ => throw new NotImplementedException($"Unsupported curve {key.Key.CurveName}"),
+            };
+
+            CryptographyClient azureClient = new CryptographyClient(key.Id, cred);
+            ECParameters pubParams = key.Key.ToECDsa(includePrivateParameters: false)
+                .ExportParameters(false);
+
+            return new Key(new AzureECDsaKey(azureClient, pubParams, sigAlgo));
+        }
+        else
+        {
+            throw new NotImplementedException($"Unsupported Azure key type {key.KeyType}");
+        }
+    }
+
+    private static async ValueTask<(TokenCredential, KeyVaultKey)> GetKeyVaultKey(string vaultName, string keyName)
+    {
+        DefaultAzureCredential cred = new(includeInteractiveCredentials: true);
+
+        string keyVaultUrl = $"https://{vaultName}.vault.azure.net/";
+        KeyClient keyClient = new KeyClient(new Uri(keyVaultUrl), cred);
+        return (cred, await keyClient.GetKeyAsync(keyName));
+    }
+
+    private static string GetRsaPubKey(RSAParameters pubParams)
+    {
+        byte[] n = pubParams.Modulus!;
+        byte[] e = pubParams.Exponent!;
+
+        // If the modulus has the highest bit set, we need to pad it with a 0
+        // byte.
+        int padding = 0;
+        if ((n[0] & 0x80) != 0)
+        {
+            padding = 1;
+        }
+
+        Span<byte> keyData = stackalloc byte[4 + 7 + 4 + e.Length + 4 + padding + n.Length];
+        BinaryPrimitives.WriteInt32BigEndian(keyData, 7);
+        Encoding.ASCII.GetBytes("ssh-rsa", keyData.Slice(4));
+        BinaryPrimitives.WriteInt32BigEndian(keyData.Slice(11), e.Length);
+        e.CopyTo(keyData.Slice(15, e.Length));
+        BinaryPrimitives.WriteInt32BigEndian(keyData.Slice(15 + e.Length), n.Length + padding);
+        keyData[19 + e.Length] = 0;
+        n.CopyTo(keyData.Slice(19 + e.Length + padding));
+
+        return $"ssh-rsa {Convert.ToBase64String(keyData)}";
+    }
+
+    private static string GetEcdsaPubKey(ECParameters pubParams)
+    {
+        byte[] x = pubParams.Q.X!;
+        byte[] y = pubParams.Q.Y!;
+
+        string curveName = pubParams.Curve.Oid?.FriendlyName switch
+        {
+            "ECDSA_P256" => "nistp256",
+            "ECDSA_P384" => "nistp384",
+            "ECDSA_P521" => "nistp521",
+            _ => throw new NotImplementedException($"Unsupported ECDSA curve {pubParams.Curve.Oid?.FriendlyName}"),
+        };
+        string keyType = $"ecdsa-sha2-{curveName}";
+
+        Span<byte> keyData = stackalloc byte[4 + keyType.Length + 4 + curveName.Length + 4 + 1 + x.Length + y.Length];
+        BinaryPrimitives.WriteInt32BigEndian(keyData, keyType.Length);
+        Encoding.ASCII.GetBytes(keyType, keyData.Slice(4));
+        BinaryPrimitives.WriteInt32BigEndian(keyData.Slice(4 + keyType.Length), curveName.Length);
+        Encoding.ASCII.GetBytes(curveName, keyData.Slice(8 + keyType.Length));
+        BinaryPrimitives.WriteInt32BigEndian(keyData.Slice(8 + keyType.Length + curveName.Length), x.Length + y.Length + 1);
+        keyData[12 + keyType.Length + curveName.Length] = 0x04;
+        x.CopyTo(keyData.Slice(13 + keyType.Length + curveName.Length));
+        y.CopyTo(keyData.Slice(13 + keyType.Length + curveName.Length + x.Length));
+
+        return $"{keyType} {Convert.ToBase64String(keyData)}";
+    }
+}

--- a/examples/azure_key/AzureKeyCredential.cs
+++ b/examples/azure_key/AzureKeyCredential.cs
@@ -1,11 +1,8 @@
 using Azure.Core;
-using Azure.Identity;
 using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using System;
-using System.Buffers.Binary;
 using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using AzureSignatureAlgorithm = Azure.Security.KeyVault.Keys.Cryptography.SignatureAlgorithm;
@@ -14,46 +11,30 @@ namespace Tmds.Ssh.AzureKeyExample;
 
 sealed class AzureKeyCredential : PrivateKeyCredential
 {
-    public AzureKeyCredential(string vaultName, string keyName) :
-        base((c) => GetAzureKey(vaultName, keyName, c), $"Azure Key Vault: {vaultName}/{keyName}")
+    public AzureKeyCredential(TokenCredential credential, KeyVaultKey key) :
+        base((c) => GetAzureKeyAsync(credential, key, c), $"azure:{key.Id}")
     { }
 
-    public static async ValueTask<string> GetAzurePubKey(string vaultName, string keyName)
+    private static ValueTask<Key> GetAzureKeyAsync(
+        TokenCredential credential,
+        KeyVaultKey key,
+        CancellationToken cancellationToken = default)
     {
-        (var _, KeyVaultKey key) = await GetKeyVaultKey(vaultName, keyName);
+        CryptographyClient azureClient = new CryptographyClient(key.Id, credential);
 
+        Key privateKey;
         if (key.KeyType == KeyType.Rsa)
         {
             RSAParameters pubParams = key.Key.ToRSA(includePrivateParameters: false)
                 .ExportParameters(false);
-            return GetRsaPubKey(pubParams);
+
+            privateKey = new Key(new AzureRsaKey(azureClient, pubParams, cancellationToken));
         }
         else if (key.KeyType == KeyType.Ec)
         {
             ECParameters pubParams = key.Key.ToECDsa(includePrivateParameters: false)
                 .ExportParameters(false);
-            return GetEcdsaPubKey(pubParams);
-        }
-        else
-        {
-            throw new NotImplementedException($"Unsupported Azure key type {key.KeyType}");
-        }
-    }
 
-    private static async ValueTask<Key> GetAzureKey(string vaultName, string keyName, CancellationToken cancellationToken = default)
-    {
-        (TokenCredential cred, KeyVaultKey key) = await GetKeyVaultKey(vaultName, keyName);
-
-        if (key.KeyType == KeyType.Rsa)
-        {
-            CryptographyClient azureClient = new CryptographyClient(key.Id, cred);
-            RSAParameters pubParams = key.Key.ToRSA(includePrivateParameters: false)
-                .ExportParameters(false);
-
-            return new Key(new AzureRsaKey(azureClient, pubParams));
-        }
-        else if (key.KeyType == KeyType.Ec)
-        {
             AzureSignatureAlgorithm sigAlgo = key.Key.CurveName.ToString() switch
             {
                 "P-256" => AzureSignatureAlgorithm.ES256,
@@ -62,76 +43,13 @@ sealed class AzureKeyCredential : PrivateKeyCredential
                 _ => throw new NotImplementedException($"Unsupported curve {key.Key.CurveName}"),
             };
 
-            CryptographyClient azureClient = new CryptographyClient(key.Id, cred);
-            ECParameters pubParams = key.Key.ToECDsa(includePrivateParameters: false)
-                .ExportParameters(false);
-
-            return new Key(new AzureECDsaKey(azureClient, pubParams, sigAlgo));
+            privateKey = new Key(new AzureECDsaKey(azureClient, pubParams, sigAlgo, cancellationToken));
         }
         else
         {
             throw new NotImplementedException($"Unsupported Azure key type {key.KeyType}");
         }
-    }
 
-    private static async ValueTask<(TokenCredential, KeyVaultKey)> GetKeyVaultKey(string vaultName, string keyName)
-    {
-        DefaultAzureCredential cred = new(includeInteractiveCredentials: true);
-
-        string keyVaultUrl = $"https://{vaultName}.vault.azure.net/";
-        KeyClient keyClient = new KeyClient(new Uri(keyVaultUrl), cred);
-        return (cred, await keyClient.GetKeyAsync(keyName));
-    }
-
-    private static string GetRsaPubKey(RSAParameters pubParams)
-    {
-        byte[] n = pubParams.Modulus!;
-        byte[] e = pubParams.Exponent!;
-
-        // If the modulus has the highest bit set, we need to pad it with a 0
-        // byte.
-        int padding = 0;
-        if ((n[0] & 0x80) != 0)
-        {
-            padding = 1;
-        }
-
-        Span<byte> keyData = stackalloc byte[4 + 7 + 4 + e.Length + 4 + padding + n.Length];
-        BinaryPrimitives.WriteInt32BigEndian(keyData, 7);
-        Encoding.ASCII.GetBytes("ssh-rsa", keyData.Slice(4));
-        BinaryPrimitives.WriteInt32BigEndian(keyData.Slice(11), e.Length);
-        e.CopyTo(keyData.Slice(15, e.Length));
-        BinaryPrimitives.WriteInt32BigEndian(keyData.Slice(15 + e.Length), n.Length + padding);
-        keyData[19 + e.Length] = 0;
-        n.CopyTo(keyData.Slice(19 + e.Length + padding));
-
-        return $"ssh-rsa {Convert.ToBase64String(keyData)}";
-    }
-
-    private static string GetEcdsaPubKey(ECParameters pubParams)
-    {
-        byte[] x = pubParams.Q.X!;
-        byte[] y = pubParams.Q.Y!;
-
-        string curveName = pubParams.Curve.Oid?.FriendlyName switch
-        {
-            "ECDSA_P256" => "nistp256",
-            "ECDSA_P384" => "nistp384",
-            "ECDSA_P521" => "nistp521",
-            _ => throw new NotImplementedException($"Unsupported ECDSA curve {pubParams.Curve.Oid?.FriendlyName}"),
-        };
-        string keyType = $"ecdsa-sha2-{curveName}";
-
-        Span<byte> keyData = stackalloc byte[4 + keyType.Length + 4 + curveName.Length + 4 + 1 + x.Length + y.Length];
-        BinaryPrimitives.WriteInt32BigEndian(keyData, keyType.Length);
-        Encoding.ASCII.GetBytes(keyType, keyData.Slice(4));
-        BinaryPrimitives.WriteInt32BigEndian(keyData.Slice(4 + keyType.Length), curveName.Length);
-        Encoding.ASCII.GetBytes(curveName, keyData.Slice(8 + keyType.Length));
-        BinaryPrimitives.WriteInt32BigEndian(keyData.Slice(8 + keyType.Length + curveName.Length), x.Length + y.Length + 1);
-        keyData[12 + keyType.Length + curveName.Length] = 0x04;
-        x.CopyTo(keyData.Slice(13 + keyType.Length + curveName.Length));
-        y.CopyTo(keyData.Slice(13 + keyType.Length + curveName.Length + x.Length));
-
-        return $"{keyType} {Convert.ToBase64String(keyData)}";
+        return ValueTask.FromResult(privateKey);
     }
 }

--- a/examples/azure_key/AzureRsaKey.cs
+++ b/examples/azure_key/AzureRsaKey.cs
@@ -1,0 +1,50 @@
+using Azure.Security.KeyVault.Keys.Cryptography;
+using System;
+using System.Security.Cryptography;
+using AzureSignatureAlgorithm = Azure.Security.KeyVault.Keys.Cryptography.SignatureAlgorithm;
+
+namespace Tmds.Ssh.AzureKeyExample;
+
+sealed class AzureRsaKey : RSA
+{
+    private readonly CryptographyClient _cryptoClient;
+    private readonly RSAParameters _publicParameters;
+
+    public AzureRsaKey(CryptographyClient client, RSAParameters publicParameters)
+    {
+        KeySizeValue = publicParameters.Modulus!.Length * 8;
+        _cryptoClient = client;
+        _publicParameters = publicParameters;
+    }
+
+    public override RSAParameters ExportParameters(bool includePrivateParameters)
+    {
+        if (includePrivateParameters)
+        {
+            throw new CryptographicException("Cannot export private parameters");
+        }
+
+        return _publicParameters;
+    }
+
+    public override void ImportParameters(RSAParameters parameters)
+        => throw new NotImplementedException();
+
+    public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
+    {
+        if (padding != RSASignaturePadding.Pkcs1)
+        {
+            throw new CryptographicException($"Unsupported padding {padding}");
+        }
+
+        AzureSignatureAlgorithm sigAlgo = hashAlgorithm.Name switch
+        {
+            "SHA256" => AzureSignatureAlgorithm.RS256,
+            "SHA512" => AzureSignatureAlgorithm.RS512,
+            _ => throw new CryptographicException($"Unsupported hash algorithm {hashAlgorithm.Name}"),
+        };
+
+        byte[] res = _cryptoClient.Sign(sigAlgo, hash).Signature;
+        return res;
+    }
+}

--- a/examples/azure_key/Program.cs
+++ b/examples/azure_key/Program.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Tmds.Ssh.AzureKeyExample;
+
+class Program
+{
+    static async Task<int> Main(string[] args)
+    {
+        if (args.Length == 0 || (args[0] != "ssh" && args[0] != "print_pub_key"))
+        {
+            Console.Error.WriteLine("Usage: azure_key {ssh,print_pub_key} <vaultName> <keyName>");
+            return 255;
+        }
+
+        string action = args[0];
+        if (args.Length < 3)
+        {
+            if (action == "ssh")
+            {
+                Console.Error.WriteLine("Usage: azure_key ssh <vaultName> <keyName> [<destination>] [<command>]");
+            }
+            else
+            {
+                Console.Error.WriteLine("Usage: azure_key print_pub_key <vaultName> <keyName>");
+            }
+            return 255;
+        }
+
+        string vaultName = args[1];
+        string keyName = args[2];
+
+        if (action == "print_pub_key")
+        {
+            return await PrintPublicKey(vaultName, keyName);
+        }
+        else
+        {
+            string destination = args.Length >= 4 ? args[3] : "localhost";
+            string command = args.Length >= 5 ? args[4] : "echo 'hello world'";
+            return await SshExec(vaultName, keyName, destination, command);
+        }
+    }
+
+    private static async Task<int> PrintPublicKey(string vaultName, string keyName)
+    {
+        string pubKey = await AzureKeyCredential.GetAzurePubKey(vaultName, keyName);
+        Console.WriteLine(pubKey);
+        return 0;
+    }
+
+    private static async Task<int> SshExec(string vaultName, string keyName, string destination, string command)
+    {
+        SshClientSettings clientSettings = new SshClientSettings(destination)
+        {
+            Credentials = [new AzureKeyCredential(vaultName, keyName)],
+        };
+        using SshClient client = new SshClient(clientSettings);
+
+        using var process = await client.ExecuteAsync(command);
+        Task[] tasks = new[]
+        {
+            PrintToConsole(process),
+            ReadInputFromConsole(process)
+        };
+        Task.WaitAny(tasks);
+        PrintExceptions(tasks);
+
+        return process.ExitCode;
+
+        static async Task PrintToConsole(RemoteProcess process)
+        {
+            await foreach ((bool isError, string line) in process.ReadAllLinesAsync())
+            {
+                Console.WriteLine(line);
+            }
+        }
+
+        static async Task ReadInputFromConsole(RemoteProcess process)
+        {
+            // note: Console doesn't have an async ReadLine that accepts a CancellationToken...
+            await Task.Yield();
+            var cancellationToken = process.ExecutionAborted;
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                string? line = Console.ReadLine();
+                if (line == null)
+                {
+                    break;
+                }
+                await process.WriteLineAsync(line);
+            }
+        }
+
+        static void PrintExceptions(Task[] tasks)
+        {
+            foreach (var task in tasks)
+            {
+                Exception? innerException = task.Exception?.InnerException;
+                if (innerException is not null)
+                {
+                    System.Console.WriteLine("Exception:");
+                    Console.WriteLine(innerException);
+                }
+            }
+        }
+    }
+}

--- a/examples/azure_key/README.md
+++ b/examples/azure_key/README.md
@@ -1,0 +1,37 @@
+# Azure Key Vault
+
+This example shows how to authenticate with a private key that is stored in an Azure Key Vault without having to export the key to the local filesystem.
+
+This example can be run in two different modes:
+- `print_pub_key` - prints the public key string of the requested key
+- `ssh` - runs the command over SSH using the private key specified
+
+## Requirements
+
+This example can use the following Azure Key Types:
+- RSA [2048|3072|4096]
+- EC P-[256|384|521]
+
+The `EC P-256K` is not supported by SSH and ED25516 keys are not currently supported in Azure Key Vault so cannot be used in this example.
+
+The client must have the ability to perform the following `dataActions` on the key:
+- Microsoft.KeyVault/vaults/keys/read
+- Microsoft.KeyVault/vaults/keys/sign/action
+
+You can either create a custom role with these actions or use a builtin role with these actions present like `Key Vault Crypto User`.
+
+## Examples
+
+These examples use the Azure app secret env vars to authenticate with a registered app and its secret non-interactively. There are other ways to authenticate with Azure like a managed identity, Azure CLI creds, interactive OAuth, etc. See [DefaultAzureCredential](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet) for more details.
+
+```bash
+export AZURE_CLIENT_ID=...
+export AZURE_TENANT_ID=...
+export AZURE_CLIENT_SECRET=...
+
+# Print pub key to add it into the authorized_keys file
+dotnet run print_pub_key ${KEY_VAULT_NAME} ${KEY_NAME}
+
+# Runs the whoami command for user on target
+dotnet run ssh ${KEY_VAULT_NAME} ${KEY_NAME} user@target whoami
+```

--- a/examples/azure_key/azure_key.csproj
+++ b/examples/azure_key/azure_key.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseAppHost>false</UseAppHost>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Tmds.Ssh\Tmds.Ssh.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+      <PackageReference Include="Azure.Identity" />
+      <PackageReference Include="Azure.Security.KeyVault.Keys" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tmds.Ssh/PrivateKeyCredential.cs
+++ b/src/Tmds.Ssh/PrivateKeyCredential.cs
@@ -95,21 +95,21 @@ public class PrivateKeyCredential : Credential
             Name algorithm;
             Name curveName;
             HashAlgorithmName hashAlgorithm;
-            if (oid.Equals(ECCurve.NamedCurves.nistP256.Oid))
+            if (OidEquals(oid, ECCurve.NamedCurves.nistP256.Oid))
             {
                 (algorithm, curveName, hashAlgorithm) = (AlgorithmNames.EcdsaSha2Nistp256, AlgorithmNames.Nistp256, HashAlgorithmName.SHA256);
             }
-            else if (oid.Equals(ECCurve.NamedCurves.nistP384.Oid))
+            else if (OidEquals(oid, ECCurve.NamedCurves.nistP384.Oid))
             {
                 (algorithm, curveName, hashAlgorithm) = (AlgorithmNames.EcdsaSha2Nistp384, AlgorithmNames.Nistp384, HashAlgorithmName.SHA384);
             }
-            else if (oid.Equals(ECCurve.NamedCurves.nistP521.Oid))
+            else if (OidEquals(oid, ECCurve.NamedCurves.nistP521.Oid))
             {
                 (algorithm, curveName, hashAlgorithm) = (AlgorithmNames.EcdsaSha2Nistp521, AlgorithmNames.Nistp521, HashAlgorithmName.SHA512);
             }
             else
             {
-                throw new NotSupportedException($"Curve {oid} is not known.");
+                throw new NotSupportedException($"Curve '{oid.FriendlyName ?? oid.Value}' is not known.");
             }
 
             PrivateKey = new ECDsaPrivateKey(ecdsa, algorithm, curveName, hashAlgorithm);
@@ -119,6 +119,9 @@ public class PrivateKeyCredential : Credential
         {
             PrivateKey = key;
         }
+
+        private static bool OidEquals(Oid oidA, Oid oidB)
+            => oidA.Value is not null && oidB.Value is not null && oidA.Value == oidB.Value;
     }
 
     internal async ValueTask<PrivateKey?> LoadKeyAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Adds an example of using this library with a private key hosted in Azure Key Vault. This also includes a fix for loading an ephemeral ECDSA key from the .NET object by properly checking the curve OID value.