### PR TITLE
SftpFileSystemEnumerator: don't throw when nested directory is no longer found during recursion

### DIFF
--- a/src/Tmds.Ssh/SftpChannel.PendingOperation.cs
+++ b/src/Tmds.Ssh/SftpChannel.PendingOperation.cs
@@ -128,6 +128,7 @@ partial class SftpChannel
                                             or (SftpError.NoSuchFile, PacketType.SSH_FXP_STAT       // GetAttributes: return null
                                                                     or PacketType.SSH_FXP_LSTAT   // GetAttributes: return null
                                                                     or PacketType.SSH_FXP_OPEN    // OpenFile: return null
+                                                                    or PacketType.SSH_FXP_OPENDIR // OpenDirectory: return null
                                                                     or PacketType.SSH_FXP_REMOVE  // DeleteFile: don't throw
                                                                     or PacketType.SSH_FXP_RMDIR   // DeleteDirectory: don't throw
                                             )
@@ -139,13 +140,18 @@ partial class SftpChannel
                 switch (RequestType, responseType)
                 {
                     case (PacketType.SSH_FXP_OPEN, _):
+                    {
                         SftpFile? file = error == SftpError.NoSuchFile ? null : new SftpFile(channel, handle: reader.ReadStringAsBytes(), (FileOpenOptions)Options!);
                         Options = null;
                         SetResult(file);
                         return;
+                    }
                     case (PacketType.SSH_FXP_OPENDIR, _):
-                        SetResult(new SftpFile(channel, handle: reader.ReadStringAsBytes(), SftpClient.DefaultFileOpenOptions));
+                    {
+                        SftpFile? file = error == SftpError.NoSuchFile ? null : new SftpFile(channel, handle: reader.ReadStringAsBytes(), SftpClient.DefaultFileOpenOptions);
+                        SetResult(file);
                         return;
+                    }
                     case (PacketType.SSH_FXP_STAT, _):
                     case (PacketType.SSH_FXP_LSTAT, _):
                     case (PacketType.SSH_FXP_FSTAT, _):

--- a/src/Tmds.Ssh/SftpChannel.cs
+++ b/src/Tmds.Ssh/SftpChannel.cs
@@ -537,7 +537,7 @@ sealed partial class SftpChannel : IDisposable
         return ExecuteAsync(packet, id, pendingOperation, cancellationToken);
     }
 
-    public ValueTask<SftpFile> OpenDirectoryAsync(string path, CancellationToken cancellationToken = default)
+    public ValueTask<SftpFile?> OpenDirectoryAsync(string path, CancellationToken cancellationToken = default)
     {
         PacketType packetType = PacketType.SSH_FXP_OPENDIR;
 
@@ -549,7 +549,7 @@ sealed partial class SftpChannel : IDisposable
         packet.WriteString(path);
 
         // note: Return as 'SftpFile' so it gets Disposed in case the open is cancelled.
-        return ExecuteAsync<SftpFile>(packet, id, pendingOperation, cancellationToken);
+        return ExecuteAsync<SftpFile?>(packet, id, pendingOperation, cancellationToken);
     }
 
     public async ValueTask CreateDirectoryAsync(string path, bool createParents = false, UnixFilePermissions permissions = SftpClient.DefaultCreateDirectoryPermissions, CancellationToken cancellationToken = default)

--- a/src/Tmds.Ssh/SftpClient.cs
+++ b/src/Tmds.Ssh/SftpClient.cs
@@ -324,12 +324,6 @@ public sealed partial class SftpClient : IDisposable
     public IAsyncEnumerable<T> GetDirectoryEntriesAsync<T>(string path, SftpFileEntryTransform<T> transform, EnumerationOptions? options = null)
         => new SftpFileSystemEnumerable<T>(this, path, transform, options ?? DefaultEnumerationOptions);
 
-    internal async ValueTask<SftpFile> OpenDirectoryAsync(string path, CancellationToken cancellationToken = default)
-    {
-        var channel = await GetChannelAsync(cancellationToken).ConfigureAwait(false);
-        return await channel.OpenDirectoryAsync(path, cancellationToken);
-    }
-
     public ValueTask CreateDirectoryAsync(string path, CancellationToken cancellationToken)
         => CreateDirectoryAsync(path, createParents: false, DefaultCreateDirectoryPermissions, cancellationToken);
 

--- a/test/Tmds.Ssh.Tests/SftpClientTests.cs
+++ b/test/Tmds.Ssh.Tests/SftpClientTests.cs
@@ -563,8 +563,10 @@ public class SftpClientTests
 
         string directoryPath = $"/tmp/{Path.GetRandomFileName()}";
         await sftpClient.CreateNewDirectoryAsync(directoryPath);
-        string childDirectoryPath = $"{directoryPath}/dir";
+        string childDirectoryPath = $"{directoryPath}/child";
         await sftpClient.CreateDirectoryAsync(childDirectoryPath);
+        string childChildDirectoryPath = $"{childDirectoryPath}/nestedchild";
+        await sftpClient.CreateDirectoryAsync(childChildDirectoryPath);
 
         bool childDirWasReturned = false;
         int count = 0;
@@ -573,7 +575,8 @@ public class SftpClientTests
             count++;
             childDirWasReturned = entry.Path == childDirectoryPath;
 
-            // Delete the directory before we can recurse into it.
+            // Delete the nested directories before we recurse into them.
+            await sftpClient.DeleteDirectoryAsync(childChildDirectoryPath);
             await sftpClient.DeleteDirectoryAsync(childDirectoryPath);
         }
 

--- a/test/Tmds.Ssh.Tests/SftpClientTests.cs
+++ b/test/Tmds.Ssh.Tests/SftpClientTests.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Tmds.Ssh.Tests;
 
@@ -9,10 +10,17 @@ public class SftpClientTests
     const int MultiPacketSize = 2 * PacketSize + 1024;
 
     private readonly SshServer _sshServer;
+    private readonly ITestOutputHelper _output;
 
-    public SftpClientTests(SshServer sshServer)
+    private void WriteMessage(string message)
+    {
+        _output.WriteLine(message);
+    }
+
+    public SftpClientTests(SshServer sshServer, ITestOutputHelper output)
     {
         _sshServer = sshServer;
+        _output = output;
     }
 
     [Fact]
@@ -536,6 +544,41 @@ public class SftpClientTests
             Assert.StartsWith("/", path);
             Assert.False(path.StartsWith("//"));
         }
+    }
+
+    [Fact]
+    public async Task EnumerateRootNotFound()
+    {
+        using var sftpClient = await _sshServer.CreateSftpClientAsync();
+
+        string path = "/no_such_dir";
+        var exception = await Assert.ThrowsAsync<SftpException>(() => sftpClient.GetDirectoryEntriesAsync(path).ToListAsync().AsTask());
+        Assert.Equal(SftpError.NoSuchFile, exception.Error);
+    }
+
+    [Fact]
+    public async Task EnumerateNestedDirNotFoundDoesNotThrow()
+    {
+        using var sftpClient = await _sshServer.CreateSftpClientAsync();
+
+        string directoryPath = $"/tmp/{Path.GetRandomFileName()}";
+        await sftpClient.CreateNewDirectoryAsync(directoryPath);
+        string childDirectoryPath = $"{directoryPath}/dir";
+        await sftpClient.CreateDirectoryAsync(childDirectoryPath);
+
+        bool childDirWasReturned = false;
+        int count = 0;
+        await foreach (var entry in sftpClient.GetDirectoryEntriesAsync(directoryPath, new Tmds.Ssh.EnumerationOptions() { RecurseSubdirectories = true }))
+        {
+            count++;
+            childDirWasReturned = entry.Path == childDirectoryPath;
+
+            // Delete the directory before we can recurse into it.
+            await sftpClient.DeleteDirectoryAsync(childDirectoryPath);
+        }
+
+        Assert.True(childDirWasReturned);
+        Assert.Equal(1, count);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes https://github.com/tmds/Tmds.Ssh/issues/245.