### PR TITLE
Remove Internal Constructor of ExecuteOptions

### DIFF
--- a/src/Tmds.Ssh/ExecuteOptions.cs
+++ b/src/Tmds.Ssh/ExecuteOptions.cs
@@ -11,8 +11,6 @@ public sealed class ExecuteOptions
     internal static readonly UTF8Encoding DefaultEncoding =
         new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
-    internal ExecuteOptions() { }
-
     public Encoding StandardInputEncoding { get; set; } = DefaultEncoding;
     public Encoding StandardErrorEncoding { get; set; } = DefaultEncoding;
     public Encoding StandardOutputEncoding { get; set; } = DefaultEncoding;


### PR DESCRIPTION
The ExecuteOptions constructor was marked as internal, which prevented it from being specified as an argument for ExecuteAsync in external applications.

To resolve this issue, I have removed the internal constructor of ExecuteOptions.