### PR TITLE
PrivateKeyCredential: support avoiding prompts for keys that server won't accept.

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,10 +489,10 @@ abstract class Credential
 class PrivateKeyCredential : Credential
 {
   PrivateKeyCredential(string path, string? password = null, string? identifier ??= path);
-  PrivateKeyCredential(string path, Func<string?> passwordPrompt, string? identifier ??= path);
+  PrivateKeyCredential(string path, Func<string?> passwordPrompt, bool queryKey = true, string? identifier ??= path);
 
   PrivateKeyCredential(char[] rawKey, string? password = null, string identifier = "[raw key]");
-  PrivateKeyCredential(char[] rawKey, Func<string?> passwordPrompt, string identifier = "[raw key]");
+  PrivateKeyCredential(char[] rawKey, Func<string?> passwordPrompt, bool queryKey = true, string identifier = "[raw key]");
 
   // Enable derived classes to use private keys from other sources.
   protected PrivateKeyCredential(Func<CancellationToken, ValueTask<Key>> loadKey, string identifier);
@@ -500,7 +500,8 @@ class PrivateKeyCredential : Credential
   {
     Key(RSA rsa);
     Key(ECDsa ecdsa);
-    Key(ReadOnlyMemory<char> rawKey, Func<string?>? passwordPrompt = null);
+    Key(ReadOnlyMemory<char> rawKey, string? password = null);
+    Key(ReadOnlyMemory<char> rawKey, Func<string?> passwordPrompt, bool queryKey = true);
   }
 }
 class PasswordCredential : Credential

--- a/src/Tmds.Ssh/AlgorithmNames.cs
+++ b/src/Tmds.Ssh/AlgorithmNames.cs
@@ -18,7 +18,7 @@ static class AlgorithmNames // TODO: rename to KnownNames
     private static readonly byte[] EcdhSha2Nistp521Bytes = "ecdh-sha2-nistp521"u8.ToArray();
     public static Name EcdhSha2Nistp521 => new Name(EcdhSha2Nistp521Bytes);
 
-    // Host key algorithms.
+    // Host key algorithms: key types and signature algorithms.
     private static readonly byte[] SshRsaBytes = "ssh-rsa"u8.ToArray();
     public static Name SshRsa => new Name(SshRsaBytes);
     private static readonly byte[] RsaSshSha2_256Bytes = "rsa-sha2-256"u8.ToArray();
@@ -33,6 +33,41 @@ static class AlgorithmNames // TODO: rename to KnownNames
     public static Name EcdsaSha2Nistp521 => new Name(EcdsaSha2Nistp521Bytes);
     private static readonly byte[] SshEd25519Bytes = "ssh-ed25519"u8.ToArray();
     public static Name SshEd25519 => new Name(SshEd25519Bytes);
+    // Key type to signature algorithms.
+    public static readonly Name[] SshRsaAlgorithms = [ RsaSshSha2_512, RsaSshSha2_256 ];
+    public static readonly Name[] EcdsaSha2Nistp256Algorithms = [ EcdsaSha2Nistp256 ];
+    public static readonly Name[] EcdsaSha2Nistp384Algorithms = [ EcdsaSha2Nistp384 ];
+    public static readonly Name[] EcdsaSha2Nistp521Algorithms = [ EcdsaSha2Nistp521 ];
+    public static readonly Name[] SshEd25519Algorithms = [ SshEd25519 ];
+
+    public static Name[] GetAlgorithmsForKeyType(Name keyType)
+    {
+        if (keyType == SshRsa)
+        {
+            return SshRsaAlgorithms;
+        }
+        else if (keyType == EcdsaSha2Nistp256)
+        {
+            return EcdsaSha2Nistp256Algorithms;
+        }
+        else if (keyType == EcdsaSha2Nistp384)
+        {
+            return EcdsaSha2Nistp384Algorithms;
+        }
+        else if (keyType == EcdsaSha2Nistp521)
+        {
+            return EcdsaSha2Nistp521Algorithms;
+        }
+        else if (keyType == SshEd25519)
+        {
+            return SshEd25519Algorithms;
+        }
+        else
+        {
+            // Unknown key types.
+            return [ keyType ];
+        }
+    }
 
     // Encryption algorithms.
     private static readonly byte[] Aes128CbcBytes = "aes128-cbc"u8.ToArray();
@@ -72,7 +107,6 @@ static class AlgorithmNames // TODO: rename to KnownNames
 
     // These fields are initialized in order, so these list must be created after the names.
     // Algorithms are in **order of preference**.
-    public static readonly Name[] SshRsaAlgorithms = [ RsaSshSha2_512, RsaSshSha2_256 ];
 
     // Authentications
     private static readonly byte[] GssApiWithMicBytes = "gssapi-with-mic"u8.ToArray();

--- a/src/Tmds.Ssh/ECDsaPrivateKey.cs
+++ b/src/Tmds.Ssh/ECDsaPrivateKey.cs
@@ -16,7 +16,7 @@ sealed class ECDsaPrivateKey : PrivateKey
     private readonly HashAlgorithmName _hashAlgorithm;
 
     public ECDsaPrivateKey(ECDsa ecdsa, Name algorithm, Name curveName, HashAlgorithmName hashAlgorithm, SshKey sshPublicKey) :
-        base([algorithm], sshPublicKey)
+        base(AlgorithmNames.GetAlgorithmsForKeyType(algorithm), sshPublicKey)
     {
         _ecdsa = ecdsa ?? throw new ArgumentNullException(nameof(ecdsa));
         _algorithm = algorithm;
@@ -41,7 +41,7 @@ sealed class ECDsaPrivateKey : PrivateKey
         return new SshKey(algorithm, writer.ToArray());
     }
 
-    public override ValueTask<byte[]?> TrySignAsync(Name algorithm, byte[] data, CancellationToken cancellationToken)
+    public override ValueTask<byte[]> SignAsync(Name algorithm, byte[] data, CancellationToken cancellationToken)
     {
         if (algorithm != _algorithm)
         {
@@ -67,6 +67,6 @@ sealed class ECDsaPrivateKey : PrivateKey
         innerWriter.WriteString(algorithm);
         innerWriter.WriteString(ecdsaSigWriter.ToArray());
 
-        return ValueTask.FromResult((byte[]?)innerWriter.ToArray());
+        return ValueTask.FromResult(innerWriter.ToArray());
     }
 }

--- a/src/Tmds.Ssh/Ed25519PrivateKey.cs
+++ b/src/Tmds.Ssh/Ed25519PrivateKey.cs
@@ -13,7 +13,7 @@ sealed class Ed25519PrivateKey : PrivateKey
     private readonly byte[] _publicKey;
 
     public Ed25519PrivateKey(byte[] privateKey, byte[] publicKey, SshKey sshPublicKey) :
-        base([AlgorithmNames.SshEd25519], sshPublicKey)
+        base(AlgorithmNames.SshEd25519Algorithms, sshPublicKey)
     {
         _privateKey = privateKey;
         _publicKey = publicKey;
@@ -31,7 +31,7 @@ sealed class Ed25519PrivateKey : PrivateKey
         return new SshKey(AlgorithmNames.SshEd25519, writer.ToArray());
     }
 
-    public override ValueTask<byte[]?> TrySignAsync(Name algorithm, byte[] data, CancellationToken cancellationToken)
+    public override ValueTask<byte[]> SignAsync(Name algorithm, byte[] data, CancellationToken cancellationToken)
     {
         if (algorithm != Algorithms[0])
         {
@@ -55,6 +55,6 @@ sealed class Ed25519PrivateKey : PrivateKey
         innerWriter.WriteString(algorithm);
         innerWriter.WriteString(signature);
 
-        return ValueTask.FromResult((byte[]?)innerWriter.ToArray());
+        return ValueTask.FromResult(innerWriter.ToArray());
     }
 }

--- a/src/Tmds.Ssh/PrivateKey.cs
+++ b/src/Tmds.Ssh/PrivateKey.cs
@@ -1,8 +1,6 @@
 // This file is part of Tmds.Ssh which is released under MIT.
 // See file LICENSE for full license details.
 
-using System.Buffers;
-
 namespace Tmds.Ssh;
 
 abstract class PrivateKey : IDisposable
@@ -18,5 +16,5 @@ abstract class PrivateKey : IDisposable
 
     public abstract void Dispose();
 
-    public abstract ValueTask<byte[]?> TrySignAsync(Name algorithm, byte[] data, CancellationToken cancellationToken);
+    public abstract ValueTask<byte[]> SignAsync(Name algorithm, byte[] data, CancellationToken cancellationToken);
 }

--- a/src/Tmds.Ssh/PrivateKeyCredential.cs
+++ b/src/Tmds.Ssh/PrivateKeyCredential.cs
@@ -12,19 +12,19 @@ public class PrivateKeyCredential : Credential
     private Func<CancellationToken, ValueTask<Key>> LoadKey { get; }
 
     public PrivateKeyCredential(string path, string? password = null, string? identifier = null) :
-        this(path, () => password, identifier)
+        this(path, () => password, queryKey: false, identifier)
     { }
 
-    public PrivateKeyCredential(string path, Func<string?> passwordPrompt, string? identifier = null) :
-        this(LoadKeyFromFile(path ?? throw new ArgumentNullException(nameof(path)), passwordPrompt), identifier ?? path)
+    public PrivateKeyCredential(string path, Func<string?> passwordPrompt, bool queryKey = true, string? identifier = null) :
+        this(LoadKeyFromFile(path ?? throw new ArgumentNullException(nameof(path)), passwordPrompt, queryKey), identifier ?? path)
     { }
 
     public PrivateKeyCredential(char[] rawKey, string? password = null, string identifier = "[raw key]") :
-        this(rawKey, () => password, identifier)
+        this(rawKey, () => password, queryKey: false, identifier)
     { }
 
-    public PrivateKeyCredential(char[] rawKey, Func<string?> passwordPrompt, string identifier = "[raw key]") :
-        this(LoadRawKey(ValidateRawKeyArgument(rawKey), passwordPrompt), identifier)
+    public PrivateKeyCredential(char[] rawKey, Func<string?> passwordPrompt, bool queryKey = true, string identifier = "[raw key]") :
+        this(LoadRawKey(ValidateRawKeyArgument(rawKey), passwordPrompt, queryKey), identifier)
     { }
 
     // Allows the user to implement derived classes that represent a private key.
@@ -43,15 +43,15 @@ public class PrivateKeyCredential : Credential
         return rawKey;
     }
 
-    private static Func<CancellationToken, ValueTask<Key>> LoadRawKey(char[] rawKey, Func<string?>? passwordPrompt)
+    private static Func<CancellationToken, ValueTask<Key>> LoadRawKey(char[] rawKey, Func<string?> passwordPrompt, bool queryKey)
         => (CancellationToken cancellationToken) =>
         {
-            Key key = new Key(rawKey.AsMemory(), passwordPrompt);
+            Key key = new Key(rawKey.AsMemory(), passwordPrompt, queryKey);
 
             return ValueTask.FromResult(key);
         };
 
-    private static Func<CancellationToken, ValueTask<Key>> LoadKeyFromFile(string path, Func<string?> passwordPrompt)
+    private static Func<CancellationToken, ValueTask<Key>> LoadKeyFromFile(string path, Func<string?> passwordPrompt, bool queryKey)
         => (CancellationToken cancellationToken) =>
         {
             string rawKey;
@@ -65,26 +65,37 @@ public class PrivateKeyCredential : Credential
                 return ValueTask.FromResult(default(Key)); // not found.
             }
 
-            Key key = new Key(rawKey.AsMemory(), passwordPrompt);
+            Key key = new Key(rawKey.AsMemory(), passwordPrompt, queryKey);
 
             return ValueTask.FromResult(key);
         };
 
     // This is a type we expose to our derive types to avoid having to expose PrivateKey and a bunch of other internals.
-    protected readonly struct Key
+    internal protected readonly struct Key : IDisposable
     {
         internal PrivateKey? PrivateKey { get; }
+
+        internal bool QueryKey { get; }
 
         public Key(RSA rsa)
         {
             PrivateKey = new RsaPrivateKey(rsa, RsaPrivateKey.DeterminePublicSshKey(rsa));
         }
 
-        public Key(ReadOnlyMemory<char> rawKey, Func<string?>? passwordPrompt = null)
+        public Key(ReadOnlyMemory<char> rawKey, string? password = null)
         {
-            passwordPrompt ??= delegate { return null; };
+            QueryKey = false;
 
-            PrivateKey = PrivateKeyParser.ParsePrivateKey(rawKey, passwordPrompt);
+            PrivateKey = PrivateKeyParser.ParsePrivateKey(rawKey, passwordPrompt: delegate { return password; });
+        }
+
+        public Key(ReadOnlyMemory<char> rawKey, Func<string?> passwordPrompt, bool queryKey = true)
+        {
+            ArgumentNullException.ThrowIfNull(passwordPrompt);
+
+            QueryKey = queryKey;
+
+            PrivateKey = queryKey ? ParsedPrivateKey.Create(rawKey, passwordPrompt) : PrivateKeyParser.ParsePrivateKey(rawKey, passwordPrompt);
         }
 
         public Key(ECDsa ecdsa)
@@ -122,11 +133,44 @@ public class PrivateKeyCredential : Credential
 
         private static bool OidEquals(Oid oidA, Oid oidB)
             => oidA.Value is not null && oidB.Value is not null && oidA.Value == oidB.Value;
+
+        public void Dispose()
+        {
+            PrivateKey?.Dispose();
+        }
     }
 
-    internal async ValueTask<PrivateKey?> LoadKeyAsync(CancellationToken cancellationToken)
+    internal async ValueTask<Key> LoadKeyAsync(CancellationToken cancellationToken)
     {
-        Key key = await LoadKey(cancellationToken);
-        return key.PrivateKey;
+        return await LoadKey(cancellationToken);
+    }
+
+    sealed class ParsedPrivateKey : PrivateKey
+    {
+        private ReadOnlyMemory<char> _rawKey;
+        private Func<string?> _passwordPrompt;
+
+        public static PrivateKey Create(ReadOnlyMemory<char> rawKey, Func<string?> passwordPrompt)
+        {
+            SshKey sshKey = PrivateKeyParser.ParsePublicKey(rawKey);
+            Name[] algorithms = AlgorithmNames.GetAlgorithmsForKeyType(sshKey.Type);
+            return new ParsedPrivateKey(algorithms, sshKey, rawKey, passwordPrompt);
+        }
+
+        private ParsedPrivateKey(Name[] algorithms, SshKey publicKey, ReadOnlyMemory<char> rawKey, Func<string?> passwordPrompt)
+            : base(algorithms, publicKey)
+        {
+            _rawKey = rawKey;
+            _passwordPrompt = passwordPrompt;
+        }
+
+        public override void Dispose()
+        { }
+
+        public override ValueTask<byte[]> SignAsync(Name algorithm, byte[] data, CancellationToken cancellationToken)
+        {
+            using PrivateKey pk = PrivateKeyParser.ParsePrivateKey(_rawKey, _passwordPrompt);
+            return pk.SignAsync(algorithm, data, cancellationToken);
+        }
     }
 }

--- a/src/Tmds.Ssh/PrivateKeyParser.cs
+++ b/src/Tmds.Ssh/PrivateKeyParser.cs
@@ -8,6 +8,12 @@ namespace Tmds.Ssh;
 partial class PrivateKeyParser
 {
     internal static PrivateKey ParsePrivateKey(ReadOnlyMemory<char> rawKey, Func<string?> passwordPrompt)
+        => ParseKey(rawKey, passwordPrompt, parsePrivate: true).PrivateKey!;
+
+    internal static SshKey ParsePublicKey(ReadOnlyMemory<char> rawKey)
+        => ParseKey(rawKey, passwordPrompt: delegate { return null; }, parsePrivate: false).PublicKey;
+
+    private static (SshKey PublicKey, PrivateKey? PrivateKey) ParseKey(ReadOnlyMemory<char> rawKey, Func<string?> passwordPrompt, bool parsePrivate)
     {
         ReadOnlySpan<char> content = rawKey.Span;
 
@@ -74,7 +80,7 @@ partial class PrivateKeyParser
         switch (keyFormat)
         {
             case "-----BEGIN OPENSSH PRIVATE KEY-----":
-                return ParseOpenSshKey(keyData, passwordPrompt);
+                return ParseOpenSshKey(keyData, passwordPrompt, parsePrivate);
             default:
                 throw new NotSupportedException($"Unsupported format: '{keyFormat}'.");
         }

--- a/src/Tmds.Ssh/RsaPrivateKey.cs
+++ b/src/Tmds.Ssh/RsaPrivateKey.cs
@@ -35,7 +35,7 @@ sealed class RsaPrivateKey : PrivateKey
         return new SshKey(AlgorithmNames.SshRsa, writer.ToArray());
     }
 
-    public override ValueTask<byte[]?> TrySignAsync(Name algorithm, byte[] data, CancellationToken cancellationToken)
+    public override ValueTask<byte[]> SignAsync(Name algorithm, byte[] data, CancellationToken cancellationToken)
     {
         HashAlgorithmName hashAlgorithmName;
         if (algorithm == AlgorithmNames.RsaSshSha2_256)
@@ -62,6 +62,6 @@ sealed class RsaPrivateKey : PrivateKey
         }
         innerWriter.WriteString(signature);
 
-        return ValueTask.FromResult((byte[]?)innerWriter.ToArray());
+        return ValueTask.FromResult(innerWriter.ToArray());
     }
 }

--- a/src/Tmds.Ssh/SshClientLogger.cs
+++ b/src/Tmds.Ssh/SshClientLogger.cs
@@ -272,7 +272,7 @@ static partial class SshClientLogger
         EventId = 31,
         Level = LogLevel.Error,
         Message = "Private key '{KeyIdentifier}' failed to sign with {Algorithm}")]
-    public static partial void PrivateKeyFailedToSign(this ILogger<SshClient> logger, string keyIdentifier, Name algorithm);
+    public static partial void PrivateKeyFailedToSign(this ILogger<SshClient> logger, string keyIdentifier, Name algorithm, Exception exception);
 
     [LoggerMessage(
         EventId = 32,


### PR DESCRIPTION
Fixes https://github.com/tmds/Tmds.Ssh/issues/285.