### PR TITLE
Add support for curve25519-sha256 key exchange method

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,8 @@ Supported server key algorithms:
 - rsa-sha2-256
 
 Supported key exchange methods:
+- curve25519-sha256
+- curve25519-sha256@libssh.org
 - ecdh-sha2-nistp256
 - ecdh-sha2-nistp384
 - ecdh-sha2-nistp521

--- a/README.md
+++ b/README.md
@@ -566,8 +566,7 @@ Supported server key algorithms:
 - rsa-sha2-256
 
 Supported key exchange methods:
-- curve25519-sha256
-- curve25519-sha256@libssh.org
+- curve25519-sha256, curve25519-sha256@libssh.org
 - ecdh-sha2-nistp256
 - ecdh-sha2-nistp384
 - ecdh-sha2-nistp521

--- a/src/Tmds.Ssh/AlgorithmNames.cs
+++ b/src/Tmds.Ssh/AlgorithmNames.cs
@@ -17,6 +17,10 @@ static class AlgorithmNames // TODO: rename to KnownNames
     public static Name EcdhSha2Nistp384 => new Name(EcdhSha2Nistp384Bytes);
     private static readonly byte[] EcdhSha2Nistp521Bytes = "ecdh-sha2-nistp521"u8.ToArray();
     public static Name EcdhSha2Nistp521 => new Name(EcdhSha2Nistp521Bytes);
+    private static readonly byte[] Curve25519Sha256Bytes = "curve25519-sha256"u8.ToArray();
+    public static Name Curve25519Sha256 => new Name(Curve25519Sha256Bytes);
+    private static readonly byte[] Curve25519Sha256LibSshBytes = "curve25519-sha256@libssh.org"u8.ToArray();
+    public static Name Curve25519Sha256LibSsh => new Name(Curve25519Sha256LibSshBytes);
 
     // Host key algorithms: key types and signature algorithms.
     private static readonly byte[] SshRsaBytes = "ssh-rsa"u8.ToArray();

--- a/src/Tmds.Ssh/BigIntegerExtensions.cs
+++ b/src/Tmds.Ssh/BigIntegerExtensions.cs
@@ -19,4 +19,7 @@ static class BigIntegerExtensions
         }
         return array;
     }
+
+    public static byte[] ToMPIntByteArray(this BigInteger integer)
+        => integer == BigInteger.Zero ? Array.Empty<byte>() : integer.ToByteArray(isUnsigned: false, isBigEndian: true);
 }

--- a/src/Tmds.Ssh/Curve25519KeyExchange.cs
+++ b/src/Tmds.Ssh/Curve25519KeyExchange.cs
@@ -1,0 +1,215 @@
+// This file is part of Tmds.Ssh which is released under MIT.
+// See file LICENSE for full license details.
+
+using System.Buffers;
+using System.Security.Cryptography;
+using System.Numerics;
+using Microsoft.Extensions.Logging;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.Crypto.Prng;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Agreement;
+
+namespace Tmds.Ssh;
+
+// Curve25519 Key Exchange: https://datatracker.ietf.org/doc/html/rfc8731
+class Curve25519KeyExchange : IKeyExchangeAlgorithm
+{
+    private readonly HashAlgorithmName _hashAlgorithmName;
+
+    public Curve25519KeyExchange(HashAlgorithmName hashAlgorithmName)
+    {
+        _hashAlgorithmName = hashAlgorithmName;
+    }
+
+    public async Task<KeyExchangeOutput> TryExchangeAsync(KeyExchangeContext context, IHostKeyVerification hostKeyVerification, Packet firstPacket, KeyExchangeInput input, ILogger logger, CancellationToken ct)
+    {
+        var sequencePool = context.SequencePool;
+        var connectionInfo = input.ConnectionInfo;
+
+        AsymmetricCipherKeyPair x25519KeyPair;
+        using (var _randomGenerator = new CryptoApiRandomGenerator())
+        {
+            var x25519KeyPairGenerator = new X25519KeyPairGenerator();
+            x25519KeyPairGenerator.Init(new X25519KeyGenerationParameters(new SecureRandom(_randomGenerator)));
+            x25519KeyPair = x25519KeyPairGenerator.GenerateKeyPair();
+        }
+
+        // Send ECDH_INIT.
+        var q_c = ((X25519PublicKeyParameters)x25519KeyPair.Public).GetEncoded();
+        await context.SendPacketAsync(CreateEcdhInitMessage(sequencePool, q_c), ct).ConfigureAwait(false);
+
+        // Receive ECDH_REPLY.
+        using Packet ecdhReplyMsg = await context.ReceivePacketAsync(MessageId.SSH_MSG_KEX_ECDH_REPLY, firstPacket.Move(), ct).ConfigureAwait(false);
+        var ecdhReply = ParceEcdhReply(ecdhReplyMsg);
+
+        // Verify received key is valid.
+        connectionInfo.ServerKey = new HostKey(ecdhReply.public_host_key);
+        await hostKeyVerification.VerifyAsync(connectionInfo, ct).ConfigureAwait(false);
+
+        var publicHostKey = PublicKey.CreateFromSshKey(ecdhReply.public_host_key);
+        if (publicHostKey is RsaPublicKey rsaPublicKey && rsaPublicKey.KeySize < input.MinimumRSAKeySize)
+        {
+            throw new ConnectFailedException(ConnectFailedReason.KeyExchangeFailed, $"Server RSA key size {rsaPublicKey.KeySize} is less than {input.MinimumRSAKeySize}.", connectionInfo);
+        }
+
+        // Compute shared secret.
+        BigInteger sharedSecret;
+        try
+        {
+            sharedSecret = DeriveSharedSecret(x25519KeyPair.Private, new X25519PublicKeyParameters(ecdhReply.q_s));
+        }
+        catch (Exception ex)
+        {
+            throw new ConnectFailedException(ConnectFailedReason.KeyExchangeFailed, "Cannot determine shared secret.", connectionInfo, ex);
+        }
+
+        // Generate exchange hash.
+        byte[] exchangeHash = CalculateExchangeHash(sequencePool, input.ConnectionInfo, input.ClientKexInitMsg, input.ServerKexInitMsg, ecdhReply.public_host_key.Data, q_c, ecdhReply.q_s, sharedSecret);
+
+        // Verify the server's signature.
+        if (!publicHostKey.VerifySignature(input.HostKeyAlgorithms, exchangeHash, ecdhReply.exchange_hash_signature))
+        {
+            throw new ConnectFailedException(ConnectFailedReason.KeyExchangeFailed, "Signature does not match host key.", connectionInfo);
+        }
+
+        byte[] sessionId = input.ConnectionInfo.SessionId ?? exchangeHash;
+        byte[] initialIVC2S = CalculateKey(sequencePool, sharedSecret, exchangeHash, (byte)'A', sessionId, input.InitialIVC2SLength);
+        byte[] initialIVS2C = CalculateKey(sequencePool, sharedSecret, exchangeHash, (byte)'B', sessionId, input.InitialIVS2CLength);
+        byte[] encryptionKeyC2S = CalculateKey(sequencePool, sharedSecret, exchangeHash, (byte)'C', sessionId, input.EncryptionKeyC2SLength);
+        byte[] encryptionKeyS2C = CalculateKey(sequencePool, sharedSecret, exchangeHash, (byte)'D', sessionId, input.EncryptionKeyS2CLength);
+        byte[] integrityKeyC2S = CalculateKey(sequencePool, sharedSecret, exchangeHash, (byte)'E', sessionId, input.IntegrityKeyC2SLength);
+        byte[] integrityKeyS2C = CalculateKey(sequencePool, sharedSecret, exchangeHash, (byte)'F', sessionId, input.IntegrityKeyS2CLength);
+
+        return new KeyExchangeOutput(exchangeHash,
+            initialIVS2C, encryptionKeyS2C, integrityKeyS2C,
+            initialIVC2S, encryptionKeyC2S, integrityKeyC2S);
+    }
+
+    private byte[] CalculateExchangeHash(SequencePool sequencePool, SshConnectionInfo connectionInfo, ReadOnlyPacket clientKexInitMsg, ReadOnlyPacket serverKexInitMsg, byte[] public_host_key, byte[] q_c, byte[] q_s, BigInteger sharedSecret)
+    {
+        /*
+            string   V_C, client's identification string (CR and LF excluded)
+            string   V_S, server's identification string (CR and LF excluded)
+            string   I_C, payload of the client's SSH_MSG_KEXINIT
+            string   I_S, payload of the server's SSH_MSG_KEXINIT
+            string   K_S, server's public host key
+            string   Q_C, client's ephemeral public key octet string
+            string   Q_S, server's ephemeral public key octet string
+            mpint    K,   shared secret
+         */
+        using Sequence sequence = sequencePool.RentSequence();
+        var writer = new SequenceWriter(sequence);
+        writer.WriteString(connectionInfo.ClientIdentificationString!);
+        writer.WriteString(connectionInfo.ServerIdentificationString!);
+        writer.WriteString(clientKexInitMsg.Payload);
+        writer.WriteString(serverKexInitMsg.Payload);
+        writer.WriteString(public_host_key);
+        writer.WriteString(q_c);
+        writer.WriteString(q_s);
+        writer.WriteMPInt(sharedSecret);
+
+        using IncrementalHash hash = IncrementalHash.CreateHash(_hashAlgorithmName);
+        foreach (var segment in sequence.AsReadOnlySequence())
+        {
+            hash.AppendData(segment.Span);
+        }
+        return hash.GetHashAndReset();
+    }
+
+    private byte[] CalculateKey(SequencePool sequencePool, BigInteger sharedSecret, byte[] exchangeHash, byte c, byte[] sessionId, int keyLength)
+    {
+        // https://tools.ietf.org/html/rfc4253#section-7.2
+
+        byte[] key = new byte[keyLength];
+        int keyOffset = 0;
+
+        // HASH(K || H || c || session_id)
+        using Sequence sequence = sequencePool.RentSequence();
+        var writer = new SequenceWriter(sequence);
+        writer.WriteMPInt(sharedSecret);
+        writer.Write(exchangeHash);
+        writer.WriteByte(c);
+        writer.Write(sessionId);
+
+        using IncrementalHash hash = IncrementalHash.CreateHash(_hashAlgorithmName);
+        foreach (var segment in sequence.AsReadOnlySequence())
+        {
+            hash.AppendData(segment.Span);
+        }
+        byte[] K1 = hash.GetHashAndReset();
+        Append(key, K1, ref keyOffset);
+
+        while (keyOffset != key.Length)
+        {
+            sequence.Clear();
+
+            // K3 = HASH(K || H || K1 || K2)
+            writer = new SequenceWriter(sequence);
+            writer.WriteMPInt(sharedSecret);
+            writer.Write(exchangeHash);
+            writer.Write(key.AsSpan(0, keyOffset));
+
+            foreach (var segment in sequence.AsReadOnlySequence())
+            {
+                hash.AppendData(segment.Span);
+            }
+            byte[] Kn = hash.GetHashAndReset();
+
+            Append(key, Kn, ref keyOffset);
+        }
+
+        return key;
+
+        static void Append(byte[] key, byte[] append, ref int offset)
+        {
+            int available = Math.Min(append.Length, key.Length - offset);
+            append.AsSpan().Slice(0, available).CopyTo(key.AsSpan(offset));
+            offset += available;
+        }
+    }
+
+    private BigInteger DeriveSharedSecret(AsymmetricKeyParameter privateKey, AsymmetricKeyParameter peerPublicKey)
+    {
+        var keyAgreement = new X25519Agreement();
+        keyAgreement.Init(privateKey);
+
+        var rawSecretAgreement = new byte[keyAgreement.AgreementSize];
+        keyAgreement.CalculateAgreement(peerPublicKey, rawSecretAgreement);
+        var sharedSecret = rawSecretAgreement.ToBigInteger();
+        rawSecretAgreement.AsSpan().Clear();
+        return sharedSecret;
+    }
+
+    public void Dispose()
+    { }
+
+    private static Packet CreateEcdhInitMessage(SequencePool sequencePool, ReadOnlySpan<byte> q_c)
+    {
+        using var packet = sequencePool.RentPacket();
+        var writer = packet.GetWriter();
+        writer.WriteMessageId(MessageId.SSH_MSG_KEX_ECDH_INIT);
+        writer.WriteString(q_c);
+        return packet.Move();
+    }
+
+    private static (
+        SshKey public_host_key,
+        byte[] q_s,
+        ReadOnlySequence<byte> exchange_hash_signature)
+        ParceEcdhReply(ReadOnlyPacket packet)
+    {
+        var reader = packet.GetReader();
+        reader.ReadMessageId(MessageId.SSH_MSG_KEX_ECDH_REPLY);
+        SshKey public_host_key = reader.ReadSshKey();
+        byte[] q_s = reader.ReadStringAsByteArray();
+        ReadOnlySequence<byte> exchange_hash_signature = reader.ReadStringAsBytes();
+        reader.ReadEnd();
+        return (
+            public_host_key,
+            q_s,
+            exchange_hash_signature);
+    }
+}

--- a/src/Tmds.Ssh/Curve25519KeyExchange.cs
+++ b/src/Tmds.Ssh/Curve25519KeyExchange.cs
@@ -25,15 +25,15 @@ class Curve25519KeyExchange : KeyExchange
         var connectionInfo = input.ConnectionInfo;
 
         AsymmetricCipherKeyPair x25519KeyPair;
-        using (var _randomGenerator = new CryptoApiRandomGenerator())
+        using (var randomGenerator = new CryptoApiRandomGenerator())
         {
             var x25519KeyPairGenerator = new X25519KeyPairGenerator();
-            x25519KeyPairGenerator.Init(new X25519KeyGenerationParameters(new SecureRandom(_randomGenerator)));
+            x25519KeyPairGenerator.Init(new X25519KeyGenerationParameters(new SecureRandom(randomGenerator)));
             x25519KeyPair = x25519KeyPairGenerator.GenerateKeyPair();
         }
 
         // Send ECDH_INIT.
-        var q_c = ((X25519PublicKeyParameters)x25519KeyPair.Public).GetEncoded();
+        byte[] q_c = ((X25519PublicKeyParameters)x25519KeyPair.Public).GetEncoded();
         await context.SendPacketAsync(CreateEcdhInitMessage(sequencePool, q_c), ct).ConfigureAwait(false);
 
         // Receive ECDH_REPLY.
@@ -41,7 +41,7 @@ class Curve25519KeyExchange : KeyExchange
         var ecdhReply = ParceEcdhReply(ecdhReplyMsg);
 
         // Verify received key is valid.
-        var publicHostKey = await VerifyHostKeyAsync(hostKeyVerification, input, ecdhReply.public_host_key, ct).ConfigureAwait(false);
+        PublicKey publicHostKey = await VerifyHostKeyAsync(hostKeyVerification, input, ecdhReply.public_host_key, ct).ConfigureAwait(false);
 
         // Compute shared secret.
         BigInteger sharedSecret;

--- a/src/Tmds.Ssh/ECDHKeyExchange.cs
+++ b/src/Tmds.Ssh/ECDHKeyExchange.cs
@@ -17,7 +17,7 @@ class ECDHKeyExchange : KeyExchange
     public ECDHKeyExchange(ECCurve ecCurve, HashAlgorithmName hashAlgorithmName)
     {
         _ecCurve = ecCurve;
-        this._hashAlgorithmName = hashAlgorithmName;
+        _hashAlgorithmName = hashAlgorithmName;
     }
 
     public override async Task<KeyExchangeOutput> TryExchangeAsync(KeyExchangeContext context, IHostKeyVerification hostKeyVerification, Packet firstPacket, KeyExchangeInput input, ILogger logger, CancellationToken ct)
@@ -36,7 +36,7 @@ class ECDHKeyExchange : KeyExchange
         var ecdhReply = ParceEcdhReply(ecdhReplyMsg);
 
         // Verify received key is valid.
-        var publicHostKey = await VerifyHostKeyAsync(hostKeyVerification, input, ecdhReply.public_host_key, ct).ConfigureAwait(false);
+        PublicKey publicHostKey = await VerifyHostKeyAsync(hostKeyVerification, input, ecdhReply.public_host_key, ct).ConfigureAwait(false);
 
         // Compute shared secret.
         BigInteger sharedSecret;

--- a/src/Tmds.Ssh/KeyExchange.cs
+++ b/src/Tmds.Ssh/KeyExchange.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tmds.Ssh;
+
+abstract class KeyExchange
+{
+    protected readonly HashAlgorithmName _hashAlgorithmName;
+
+    public KeyExchange(HashAlgorithmName hashAlgorithmName)
+    {
+        this._hashAlgorithmName = hashAlgorithmName;
+    }
+
+    public static async Task<PublicKey> VerifyHostKeyAsync(IHostKeyVerification hostKeyVerification, KeyExchangeInput input, SshKey public_host_key, CancellationToken ct)
+    {
+        var connectionInfo = input.ConnectionInfo;
+        connectionInfo.ServerKey = new HostKey(public_host_key);
+        await hostKeyVerification.VerifyAsync(connectionInfo, ct).ConfigureAwait(false);
+
+        var publicHostKey = PublicKey.CreateFromSshKey(public_host_key);
+        if (publicHostKey is RsaPublicKey rsaPublicKey && rsaPublicKey.KeySize < input.MinimumRSAKeySize)
+        {
+            throw new ConnectFailedException(ConnectFailedReason.KeyExchangeFailed, $"Server RSA key size {rsaPublicKey.KeySize} is less than {input.MinimumRSAKeySize}.", connectionInfo);
+        }
+
+        return publicHostKey;
+    }
+
+    public static void VerifySignature(PublicKey publicHostKey, IReadOnlyList<Name> allowedAlgorithms, byte[] exchangeHash, ReadOnlySequence<byte> exchange_hash_signature, SshConnectionInfo connectionInfo)
+    {
+        if (!publicHostKey.VerifySignature(allowedAlgorithms, exchangeHash, exchange_hash_signature))
+        {
+            throw new ConnectFailedException(ConnectFailedReason.KeyExchangeFailed, "Signature does not match host key.", connectionInfo);
+        }
+    }
+
+    public KeyExchangeOutput CalculateKeyExchangeOutput(KeyExchangeInput input, SequencePool sequencePool, BigInteger sharedSecret, byte[] exchangeHash)
+    {
+        byte[] sessionId = input.ConnectionInfo.SessionId ?? exchangeHash;
+        byte[] initialIVC2S = CalculateKey(sequencePool, sharedSecret, exchangeHash, (byte)'A', sessionId, input.InitialIVC2SLength);
+        byte[] initialIVS2C = CalculateKey(sequencePool, sharedSecret, exchangeHash, (byte)'B', sessionId, input.InitialIVS2CLength);
+        byte[] encryptionKeyC2S = CalculateKey(sequencePool, sharedSecret, exchangeHash, (byte)'C', sessionId, input.EncryptionKeyC2SLength);
+        byte[] encryptionKeyS2C = CalculateKey(sequencePool, sharedSecret, exchangeHash, (byte)'D', sessionId, input.EncryptionKeyS2CLength);
+        byte[] integrityKeyC2S = CalculateKey(sequencePool, sharedSecret, exchangeHash, (byte)'E', sessionId, input.IntegrityKeyC2SLength);
+        byte[] integrityKeyS2C = CalculateKey(sequencePool, sharedSecret, exchangeHash, (byte)'F', sessionId, input.IntegrityKeyS2CLength);
+
+        return new KeyExchangeOutput(exchangeHash,
+            initialIVS2C, encryptionKeyS2C, integrityKeyS2C,
+            initialIVC2S, encryptionKeyC2S, integrityKeyC2S);
+    }
+
+    private byte[] CalculateKey(SequencePool sequencePool, BigInteger sharedSecret, byte[] exchangeHash, byte c, byte[] sessionId, int keyLength)
+    {
+        // https://tools.ietf.org/html/rfc4253#section-7.2
+
+        byte[] key = new byte[keyLength];
+        int keyOffset = 0;
+
+        // HASH(K || H || c || session_id)
+        using Sequence sequence = sequencePool.RentSequence();
+        var writer = new SequenceWriter(sequence);
+        writer.WriteMPInt(sharedSecret);
+        writer.Write(exchangeHash);
+        writer.WriteByte(c);
+        writer.Write(sessionId);
+
+        using IncrementalHash hash = IncrementalHash.CreateHash(_hashAlgorithmName);
+        foreach (var segment in sequence.AsReadOnlySequence())
+        {
+            hash.AppendData(segment.Span);
+        }
+        byte[] K1 = hash.GetHashAndReset();
+        Append(key, K1, ref keyOffset);
+
+        while (keyOffset != key.Length)
+        {
+            sequence.Clear();
+
+            // K3 = HASH(K || H || K1 || K2)
+            writer = new SequenceWriter(sequence);
+            writer.WriteMPInt(sharedSecret);
+            writer.Write(exchangeHash);
+            writer.Write(key.AsSpan(0, keyOffset));
+
+            foreach (var segment in sequence.AsReadOnlySequence())
+            {
+                hash.AppendData(segment.Span);
+            }
+            byte[] Kn = hash.GetHashAndReset();
+
+            Append(key, Kn, ref keyOffset);
+        }
+
+        return key;
+
+        static void Append(byte[] key, byte[] append, ref int offset)
+        {
+            int available = Math.Min(append.Length, key.Length - offset);
+            append.AsSpan().Slice(0, available).CopyTo(key.AsSpan(offset));
+            offset += available;
+        }
+    }
+
+}

--- a/src/Tmds.Ssh/KeyExchange.cs
+++ b/src/Tmds.Ssh/KeyExchange.cs
@@ -32,7 +32,7 @@ abstract class KeyExchange : IKeyExchangeAlgorithm
         }
     }
 
-    protected static KeyExchangeOutput CalculateKeyExchangeOutput(KeyExchangeInput input, SequencePool sequencePool, BigInteger sharedSecret, byte[] exchangeHash, HashAlgorithmName hashAlgorithmName)
+    protected static KeyExchangeOutput CalculateKeyExchangeOutput(KeyExchangeInput input, SequencePool sequencePool, byte[] sharedSecret, byte[] exchangeHash, HashAlgorithmName hashAlgorithmName)
     {
         byte[] sessionId = input.ConnectionInfo.SessionId ?? exchangeHash;
         byte[] initialIVC2S = CalculateKey(sequencePool, sharedSecret, exchangeHash, (byte)'A', sessionId, input.InitialIVC2SLength, hashAlgorithmName);
@@ -47,7 +47,7 @@ abstract class KeyExchange : IKeyExchangeAlgorithm
             initialIVC2S, encryptionKeyC2S, integrityKeyC2S);
     }
 
-    protected static byte[] CalculateKey(SequencePool sequencePool, BigInteger sharedSecret, byte[] exchangeHash, byte c, byte[] sessionId, int keyLength, HashAlgorithmName hashAlgorithmName)
+    protected static byte[] CalculateKey(SequencePool sequencePool, byte[] sharedSecret, byte[] exchangeHash, byte c, byte[] sessionId, int keyLength, HashAlgorithmName hashAlgorithmName)
     {
         // https://tools.ietf.org/html/rfc4253#section-7.2
 
@@ -57,7 +57,7 @@ abstract class KeyExchange : IKeyExchangeAlgorithm
         // HASH(K || H || c || session_id)
         using Sequence sequence = sequencePool.RentSequence();
         var writer = new SequenceWriter(sequence);
-        writer.WriteMPInt(sharedSecret);
+        writer.WriteString(sharedSecret);
         writer.Write(exchangeHash);
         writer.WriteByte(c);
         writer.Write(sessionId);
@@ -76,7 +76,7 @@ abstract class KeyExchange : IKeyExchangeAlgorithm
 
             // K3 = HASH(K || H || K1 || K2)
             writer = new SequenceWriter(sequence);
-            writer.WriteMPInt(sharedSecret);
+            writer.WriteString(sharedSecret);
             writer.Write(exchangeHash);
             writer.Write(key.AsSpan(0, keyOffset));
 

--- a/src/Tmds.Ssh/KeyExchangeAlgorithmFactory.cs
+++ b/src/Tmds.Ssh/KeyExchangeAlgorithmFactory.cs
@@ -17,6 +17,8 @@ sealed class KeyExchangeAlgorithmFactory
         _algorithms.Add(AlgorithmNames.EcdhSha2Nistp256, name => new ECDHKeyExchange(ECCurve.NamedCurves.nistP256, HashAlgorithmName.SHA256));
         _algorithms.Add(AlgorithmNames.EcdhSha2Nistp384, name => new ECDHKeyExchange(ECCurve.NamedCurves.nistP384, HashAlgorithmName.SHA384));
         _algorithms.Add(AlgorithmNames.EcdhSha2Nistp521, name => new ECDHKeyExchange(ECCurve.NamedCurves.nistP521, HashAlgorithmName.SHA512));
+        _algorithms.Add(AlgorithmNames.Curve25519Sha256, name => new Curve25519KeyExchange(HashAlgorithmName.SHA256));
+        _algorithms.Add(AlgorithmNames.Curve25519Sha256LibSsh, name => new Curve25519KeyExchange(HashAlgorithmName.SHA256));
     }
 
     public IKeyExchangeAlgorithm Create(Name name)

--- a/src/Tmds.Ssh/KeyExchangeAlgorithmFactory.cs
+++ b/src/Tmds.Ssh/KeyExchangeAlgorithmFactory.cs
@@ -17,8 +17,8 @@ sealed class KeyExchangeAlgorithmFactory
         _algorithms.Add(AlgorithmNames.EcdhSha2Nistp256, name => new ECDHKeyExchange(ECCurve.NamedCurves.nistP256, HashAlgorithmName.SHA256));
         _algorithms.Add(AlgorithmNames.EcdhSha2Nistp384, name => new ECDHKeyExchange(ECCurve.NamedCurves.nistP384, HashAlgorithmName.SHA384));
         _algorithms.Add(AlgorithmNames.EcdhSha2Nistp521, name => new ECDHKeyExchange(ECCurve.NamedCurves.nistP521, HashAlgorithmName.SHA512));
-        _algorithms.Add(AlgorithmNames.Curve25519Sha256, name => new Curve25519KeyExchange(HashAlgorithmName.SHA256));
-        _algorithms.Add(AlgorithmNames.Curve25519Sha256LibSsh, name => new Curve25519KeyExchange(HashAlgorithmName.SHA256));
+        _algorithms.Add(AlgorithmNames.Curve25519Sha256, name => new Curve25519KeyExchange());
+        _algorithms.Add(AlgorithmNames.Curve25519Sha256LibSsh, name => new Curve25519KeyExchange());
     }
 
     public IKeyExchangeAlgorithm Create(Name name)

--- a/src/Tmds.Ssh/SshClientSettings.Defaults.cs
+++ b/src/Tmds.Ssh/SshClientSettings.Defaults.cs
@@ -41,7 +41,7 @@ partial class SshClientSettings
 
     // Algorithms are in **order of preference**.
     private readonly static List<Name> EmptyList = [];
-    internal readonly static List<Name> SupportedKeyExchangeAlgorithms = [ AlgorithmNames.EcdhSha2Nistp256, AlgorithmNames.EcdhSha2Nistp384, AlgorithmNames.EcdhSha2Nistp521 ];
+    internal readonly static List<Name> SupportedKeyExchangeAlgorithms = [ AlgorithmNames.Curve25519Sha256, AlgorithmNames.Curve25519Sha256LibSsh, AlgorithmNames.EcdhSha2Nistp256, AlgorithmNames.EcdhSha2Nistp384, AlgorithmNames.EcdhSha2Nistp521 ];
     internal readonly static List<Name> SupportedServerHostKeyAlgorithms = [ AlgorithmNames.SshEd25519, AlgorithmNames.EcdsaSha2Nistp521, AlgorithmNames.EcdsaSha2Nistp384, AlgorithmNames.EcdsaSha2Nistp256, AlgorithmNames.RsaSshSha2_512, AlgorithmNames.RsaSshSha2_256 ];
     internal readonly static List<Name> SupportedEncryptionAlgorithms = CreatePreferredEncryptionAlgorithms();
     internal readonly static IReadOnlyList<Name> SupportedPublicKeyAlgorithms = [ AlgorithmNames.SshEd25519, AlgorithmNames.EcdsaSha2Nistp521, AlgorithmNames.EcdsaSha2Nistp384, AlgorithmNames.EcdsaSha2Nistp256, AlgorithmNames.RsaSshSha2_512, AlgorithmNames.RsaSshSha2_256 ];

--- a/test/Tmds.Ssh.Tests/KeyExchangeAlgorithmTests.cs
+++ b/test/Tmds.Ssh.Tests/KeyExchangeAlgorithmTests.cs
@@ -1,0 +1,26 @@
+﻿using Xunit;
+
+namespace Tmds.Ssh.Tests;
+
+[Collection(nameof(SshServerCollection))]
+public class KeyExchangeAlgorithmTests
+{
+    private readonly SshServer _sshServer;
+
+    public KeyExchangeAlgorithmTests(SshServer sshServer)
+    {
+        _sshServer = sshServer;
+    }
+
+    [Theory]
+    [MemberData(nameof(Algorithms))]
+    public async Task ConnectWithKeyExchangeAlgorithm(string algorithm)
+    {
+        using var _ = await _sshServer.CreateClientAsync(
+            settings => settings.KeyExchangeAlgorithms = [new Name(algorithm)]
+        );
+    }
+
+    public static IEnumerable<object[]> Algorithms =>
+        SshClientSettings.SupportedKeyExchangeAlgorithms.Select(algorithm => new object[] { algorithm.ToString() });
+}

--- a/test/Tmds.Ssh.Tests/SshClientSettingsTests.cs
+++ b/test/Tmds.Ssh.Tests/SshClientSettingsTests.cs
@@ -21,7 +21,7 @@ public class ClientSettingsTests
         Assert.Equal(new[] { DefaultKnownHostsFile }, settings.UserKnownHostsFilePaths);
         Assert.Equal(new[] { DefaultGlobalKnownHostsFile }, settings.GlobalKnownHostsFilePaths);
         Assert.Null(settings.HostAuthentication);
-        Assert.Equal(new[] { new Name("ecdh-sha2-nistp256"), new Name("ecdh-sha2-nistp384"), new Name("ecdh-sha2-nistp521") }, settings.KeyExchangeAlgorithms);
+        Assert.Equal(new[] { new Name("curve25519-sha256"), new Name("curve25519-sha256@libssh.org"), new Name("ecdh-sha2-nistp256"), new Name("ecdh-sha2-nistp384"), new Name("ecdh-sha2-nistp521") }, settings.KeyExchangeAlgorithms);
         Assert.Equal(new[] { new Name("ssh-ed25519"), new Name("ecdsa-sha2-nistp521"), new Name("ecdsa-sha2-nistp384"), new Name("ecdsa-sha2-nistp256"), new Name("rsa-sha2-512"), new Name("rsa-sha2-256") }, settings.ServerHostKeyAlgorithms);
         Assert.Null(settings.PublicKeyAcceptedAlgorithms);
         Assert.Equal(new[] { new Name("ssh-ed25519"), new Name("ecdsa-sha2-nistp521"), new Name("ecdsa-sha2-nistp384"), new Name("ecdsa-sha2-nistp256"), new Name("rsa-sha2-512"), new Name("rsa-sha2-256") }, SshClientSettings.SupportedPublicKeyAlgorithms);


### PR DESCRIPTION
This PR adds support for `curve25519-sha2` key exchange method described by https://datatracker.ietf.org/doc/html/rfc8731

Close https://github.com/tmds/Tmds.Ssh/issues/307