### PR TITLE
RemoteProcess: change ReadToEndAsStringAsync nullability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ class RemoteProcess : IDisposable
 {
   // Read from the remote process.
   ValueTask<(bool isError, string? line)> ReadLineAsync(bool readStdout = true, bool readStderr = true, CancellationToken cancellationToken = default);
-  ValueTask<(string? stdout, string? stderr)> ReadToEndAsStringAsync(bool readStdout = true, bool readStderr = true, CancellationToken cancellationToken = default);
+  ValueTask<(string stdout, string stderr)> ReadToEndAsStringAsync(bool readStdout = true, bool readStderr = true, CancellationToken cancellationToken = default);
   IAsyncEnumerable<(bool isError, string line)> ReadAllLinesAsync(bool readStdout = true, bool readStderr = true, CancellationToken cancellationToken = default);
   ValueTask ReadToEndAsync(Stream? stdoutStream, Stream? stderrStream, CancellationToken? cancellationToken);
   ValueTask<(bool isError, int bytesRead)> ReadAsync(Memory<byte>? stdoutBuffer, Memory<byte>? stderrBuffer, CancellationToken cancellationToken = default);

--- a/src/Tmds.Ssh/RemoteProcess.cs
+++ b/src/Tmds.Ssh/RemoteProcess.cs
@@ -357,7 +357,7 @@ public sealed class RemoteProcess : IDisposable
         return ReadToEndAsync(null, null, null, null, cancellationToken);
     }
 
-    public async ValueTask<(string? stdout, string? stderr)> ReadToEndAsStringAsync(bool readStdout = true, bool readStderr = true, CancellationToken cancellationToken = default)
+    public async ValueTask<(string stdout, string stderr)> ReadToEndAsStringAsync(bool readStdout = true, bool readStderr = true, CancellationToken cancellationToken = default)
     {
         CheckReadMode(ReadMode.ReadChars);
 
@@ -367,8 +367,8 @@ public sealed class RemoteProcess : IDisposable
             if (readType == ProcessReadType.ProcessExit)
             {
                 _readMode = ReadMode.Exited;
-                string? stdout = readStdout ? _stdoutBuffer.BuildString() : null;
-                string? stderr = readStderr ? _stderrBuffer.BuildString() : null;
+                string stdout = readStdout ? _stdoutBuffer.BuildString()! : "";
+                string stderr = readStderr ? _stderrBuffer.BuildString()! : "";
                 return (stdout, stderr);
             }
         }

--- a/test/Tmds.Ssh.Tests/KerberosTests.cs
+++ b/test/Tmds.Ssh.Tests/KerberosTests.cs
@@ -96,9 +96,9 @@ public class KerberosTests : IDisposable
 
                 {
                     using var process = await client.ExecuteAsync("whoami");
-                    (string? stdout, string? stderr) = await process.ReadToEndAsStringAsync();
+                    (string stdout, string stderr) = await process.ReadToEndAsStringAsync();
                     Assert.Equal(0, process.ExitCode);
-                    Assert.Equal(userName, stdout?.Trim());
+                    Assert.Equal(userName, stdout.Trim());
                 }
             },
             [ connectionName, targetName ?? string.Empty, _sshServer.KnownHostsFilePath, userName, _sshServer.TestKerberosCredential.UserName, _sshServer.TestKerberosCredential.Password ]
@@ -163,14 +163,14 @@ public class KerberosTests : IDisposable
 
                 {
                     using var process = await client.ExecuteAsync("whoami");
-                    (string? stdout, string? stderr) = await process.ReadToEndAsStringAsync();
+                    (string stdout, string stderr) = await process.ReadToEndAsStringAsync();
                     Assert.Equal(0, process.ExitCode);
-                    Assert.Equal(userName, stdout?.Trim());
+                    Assert.Equal(userName, stdout.Trim());
                 }
 
                 {
                     using var process = await client.ExecuteAsync("klist -f");
-                    (string? stdout, string? stderr) = await process.ReadToEndAsStringAsync();
+                    (string stdout, string stderr) = await process.ReadToEndAsStringAsync();
 
                     if (requestDelegate)
                     {

--- a/test/Tmds.Ssh.Tests/RemoteProcessTests.cs
+++ b/test/Tmds.Ssh.Tests/RemoteProcessTests.cs
@@ -294,9 +294,9 @@ public class RemoteProcess
         await process.WriteLineAsync("echo -n 'hello stderr2' >&2");
         await process.WriteLineAsync("exit 0");
 
-        (string? stdout, string? stderr) = await process.ReadToEndAsStringAsync(readStdout, readStderr);
-        Assert.Equal(readStdout ? "hello stdout1hello stdout2" : null, stdout);
-        Assert.Equal(readStderr ? "hello stderr1hello stderr2" : null, stderr);
+        (string stdout, string stderr) = await process.ReadToEndAsStringAsync(readStdout, readStderr);
+        Assert.Equal(readStdout ? "hello stdout1hello stdout2" : "", stdout);
+        Assert.Equal(readStderr ? "hello stderr1hello stderr2" : "", stderr);
     }
 
     [Theory]


### PR DESCRIPTION
The nullable return value force users to deal with nullability. Rather than return null for stdout/stderr that gets skipped, change to return an empty string.