### PR TITLE
[breaking] Rename DirectForward to LocalForward.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ class SshClient : IDisposable
 
   // bindEP can be an IPEndPoint or a UnixDomainSocketEndPoint.
   // remoteEP can be a RemoteHostEndPoint, a RemoteUnixEndPoint or a RemoteIPEndPoint.
-  Task<DirectForward> StartForwardAsync(EndPoint bindEP, RemoteEndPoint remoteEP, CancellationToken cancellationToken = default);
+  Task<LocalForward> StartForwardAsync(EndPoint bindEP, RemoteEndPoint remoteEP, CancellationToken cancellationToken = default);
   Task<SocksForward> StartForwardSocksAsync(EndPoint bindEP, CancellationToken cancellationToken = default);
 
   // bindEP can be a RemoteIPListenEndPoint or a RemoteUnixEndPoint.
@@ -136,7 +136,7 @@ class RemoteUnixEndPoint(string path) : RemoteEndPoint
 { }
 class RemoteIPListenEndPoint(string address, int port) : RemoteEndPoint
 { }
-class DirectForward : IDisposable
+class LocalForward : IDisposable
 {
   EndPoint LocalEndPoint { get; }
   CancellationToken Stopped { get; }

--- a/src/Tmds.Ssh/LocalForward.cs
+++ b/src/Tmds.Ssh/LocalForward.cs
@@ -6,11 +6,11 @@ using Microsoft.Extensions.Logging;
 
 namespace Tmds.Ssh;
 
-public sealed class DirectForward : IDisposable
+public sealed class LocalForward : IDisposable
 {
-    private readonly LocalForwardServer<DirectForward> _forwarder;
+    private readonly LocalForwardServer<LocalForward> _forwarder;
 
-    internal DirectForward(ILogger<DirectForward> logger)
+    internal LocalForward(ILogger<LocalForward> logger)
     {
         _forwarder = new(logger);
     }

--- a/src/Tmds.Ssh/SshClient.cs
+++ b/src/Tmds.Ssh/SshClient.cs
@@ -294,11 +294,11 @@ public sealed partial class SshClient : IDisposable
         return await session.OpenUnixConnectionChannelAsync(path, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<DirectForward> StartForwardAsync(EndPoint bindEP, RemoteEndPoint remoteEP, CancellationToken cancellationToken = default)
+    public async Task<LocalForward> StartForwardAsync(EndPoint bindEP, RemoteEndPoint remoteEP, CancellationToken cancellationToken = default)
     {
         SshSession session = await GetSessionAsync(cancellationToken).ConfigureAwait(false);
 
-        var forward = new DirectForward(_loggers.DirectForwardLogger);
+        var forward = new LocalForward(_loggers.DirectForwardLogger);
         await forward.StartAsync(session, bindEP, remoteEP, cancellationToken).ConfigureAwait(false);
         return forward;
     }

--- a/src/Tmds.Ssh/SshLoggers.cs
+++ b/src/Tmds.Ssh/SshLoggers.cs
@@ -9,7 +9,7 @@ sealed class SshLoggers
 
     public ILogger<SshClient> SshClientLogger { get; }
 
-    public ILogger<DirectForward> DirectForwardLogger => Factory.CreateLogger<DirectForward>();
+    public ILogger<LocalForward> DirectForwardLogger => Factory.CreateLogger<LocalForward>();
 
     public ILogger<SocksForward> SocksForwardLogger => Factory.CreateLogger<SocksForward>();
 

--- a/test/Tmds.Ssh.Tests/LocalForwardTests.cs
+++ b/test/Tmds.Ssh.Tests/LocalForwardTests.cs
@@ -76,7 +76,7 @@ public class LocalForwardTests
         await AssertForwards(directForward);
     }
 
-    private async Task AssertForwards(DirectForward directForward)
+    private async Task AssertForwards(LocalForward directForward)
     {
         byte[] helloWorldBytes = Encoding.UTF8.GetBytes("hello world");
         byte[] receiveBuffer = new byte[128];

--- a/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
+++ b/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
@@ -7,13 +7,6 @@ namespace Tmds.Ssh
         public CertificateCredential(string path, Tmds.Ssh.PrivateKeyCredential privateKey) { }
     }
     public abstract class Credential { }
-    public sealed class DirectForward : System.IDisposable
-    {
-        public System.Net.EndPoint LocalEndPoint { get; }
-        public System.Threading.CancellationToken Stopped { get; }
-        public void Dispose() { }
-        public void ThrowIfStopped() { }
-    }
     public sealed class DownloadEntriesOptions
     {
         public DownloadEntriesOptions() { }
@@ -95,6 +88,13 @@ namespace Tmds.Ssh
         public string ToFullPath() { }
     }
     public delegate bool LocalFileEntryPredicate(ref Tmds.Ssh.LocalFileEntry entry);
+    public sealed class LocalForward : System.IDisposable
+    {
+        public System.Net.EndPoint LocalEndPoint { get; }
+        public System.Threading.CancellationToken Stopped { get; }
+        public void Dispose() { }
+        public void ThrowIfStopped() { }
+    }
     public sealed class NoCredential : Tmds.Ssh.Credential
     {
         public NoCredential() { }
@@ -416,7 +416,7 @@ namespace Tmds.Ssh
         public System.Threading.Tasks.Task<Tmds.Ssh.SftpClient> OpenSftpClientAsync(Tmds.Ssh.SftpClientOptions? options = null, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task<Tmds.Ssh.SshDataStream> OpenTcpConnectionAsync(string host, int port, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task<Tmds.Ssh.SshDataStream> OpenUnixConnectionAsync(string path, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.Task<Tmds.Ssh.DirectForward> StartForwardAsync(System.Net.EndPoint bindEP, Tmds.Ssh.RemoteEndPoint remoteEP, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<Tmds.Ssh.LocalForward> StartForwardAsync(System.Net.EndPoint bindEP, Tmds.Ssh.RemoteEndPoint remoteEP, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task<Tmds.Ssh.RemoteForward> StartRemoteForwardAsync(Tmds.Ssh.RemoteEndPoint bindEP, System.Net.EndPoint localEP, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task<Tmds.Ssh.SocksForward> StartSocksForward(System.Net.EndPoint bindEP, System.Threading.CancellationToken cancellationToken = default) { }
     }


### PR DESCRIPTION
This is for consistency with 'RemoteForward'.