### PR TITLE
[breaking] {Local,Remote,Socks}Forward: rename EndPoint property to ListenEndPoint

### DIFF
--- a/src/Tmds.Ssh/LocalForward.cs
+++ b/src/Tmds.Ssh/LocalForward.cs
@@ -18,7 +18,7 @@ public sealed class LocalForward : IDisposable
     internal ValueTask StartAsync(SshSession session, EndPoint bindEP, RemoteEndPoint remoteEndPoint, CancellationToken cancellationToken)
         => _forwarder.StartDirectForwardAsync(session, bindEP, remoteEndPoint, cancellationToken);
 
-    public EndPoint LocalEndPoint
+    public EndPoint ListenEndPoint
         => _forwarder.LocalEndPoint;
 
     public CancellationToken Stopped

--- a/src/Tmds.Ssh/RemoteForward.cs
+++ b/src/Tmds.Ssh/RemoteForward.cs
@@ -18,7 +18,7 @@ public sealed class RemoteForward : IDisposable
     internal ValueTask StartAsync(SshSession session, RemoteEndPoint bindEP, EndPoint localEndPoint, CancellationToken cancellationToken)
         => _forwarder.StartDirectForwardAsync(session, bindEP, localEndPoint, cancellationToken);
 
-    public RemoteEndPoint RemoteEndPoint
+    public RemoteEndPoint ListenEndPoint
         => _forwarder.RemoteEndPoint;
 
     public CancellationToken Stopped

--- a/src/Tmds.Ssh/SocksForward.cs
+++ b/src/Tmds.Ssh/SocksForward.cs
@@ -18,7 +18,7 @@ public sealed class SocksForward : IDisposable
     internal ValueTask StartAsync(SshSession session, EndPoint bindEP, CancellationToken cancellationToken)
         => _forwarder.StartSocksForwardAsync(session, bindEP, cancellationToken);
 
-    public EndPoint LocalEndPoint
+    public EndPoint ListenEndPoint
         => _forwarder.LocalEndPoint;
 
     public CancellationToken Stopped

--- a/test/Tmds.Ssh.Tests/LocalForwardTests.cs
+++ b/test/Tmds.Ssh.Tests/LocalForwardTests.cs
@@ -82,7 +82,7 @@ public class LocalForwardTests
         byte[] receiveBuffer = new byte[128];
         for (int i = 0; i < 2; i++)
         {
-            EndPoint endPoint = directForward.LocalEndPoint!;
+            EndPoint endPoint = directForward.ListenEndPoint!;
             using var socket = new Socket(endPoint.AddressFamily, SocketType.Stream, endPoint.AddressFamily == AddressFamily.InterNetwork ? ProtocolType.Tcp : ProtocolType.Unspecified);
             if (socket.ProtocolType == ProtocolType.Tcp)
             {
@@ -110,7 +110,7 @@ public class LocalForwardTests
         byte[] helloWorldBytes = Encoding.UTF8.GetBytes("hello world");
         byte[] receiveBuffer = new byte[128];
 
-        EndPoint endPoint = socksForward.LocalEndPoint!;
+        EndPoint endPoint = socksForward.ListenEndPoint!;
         using var socket = new Socket(endPoint.AddressFamily, SocketType.Stream, endPoint.AddressFamily == AddressFamily.InterNetwork ? ProtocolType.Tcp : ProtocolType.Unspecified);
         if (socket.ProtocolType == ProtocolType.Tcp)
         {
@@ -203,7 +203,7 @@ public class LocalForwardTests
 
         using var directForward = await client.StartForwardAsync(new IPEndPoint(IPAddress.Loopback, 0), new RemoteHostEndPoint("localhost", 5000));
         CancellationToken ct = directForward.Stopped;
-        EndPoint? endPoint = directForward.LocalEndPoint;
+        EndPoint? endPoint = directForward.ListenEndPoint;
 
         Assert.False(ct.IsCancellationRequested);
         Assert.NotNull(endPoint);
@@ -211,7 +211,7 @@ public class LocalForwardTests
         directForward.Dispose();
 
         Assert.True(ct.IsCancellationRequested);
-        Assert.Throws<ObjectDisposedException>(() => directForward.LocalEndPoint);
+        Assert.Throws<ObjectDisposedException>(() => directForward.ListenEndPoint);
         Assert.Throws<ObjectDisposedException>(() => directForward.Stopped);
         Assert.Throws<ObjectDisposedException>(() => directForward.ThrowIfStopped());
 
@@ -226,7 +226,7 @@ public class LocalForwardTests
 
         using var directForward = await client.StartForwardAsync(new IPEndPoint(IPAddress.Loopback, 0), new RemoteHostEndPoint("localhost", 5000));
         CancellationToken ct = directForward.Stopped;
-        EndPoint? endPoint = directForward.LocalEndPoint;
+        EndPoint? endPoint = directForward.ListenEndPoint;
 
         Assert.False(ct.IsCancellationRequested);
         Assert.NotNull(endPoint);
@@ -234,7 +234,7 @@ public class LocalForwardTests
         client.Dispose();
 
         Assert.True(ct.IsCancellationRequested);
-        endPoint = directForward.LocalEndPoint;
+        endPoint = directForward.ListenEndPoint;
         Assert.NotNull(endPoint);
         Assert.True(directForward.Stopped.IsCancellationRequested);
         Assert.Throws<SshConnectionClosedException>(() => directForward.ThrowIfStopped());
@@ -252,6 +252,6 @@ public class LocalForwardTests
         
         using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 
-        await socket.ConnectAsync(new IPEndPoint(IPAddress.Loopback, (directForward.LocalEndPoint as IPEndPoint)!.Port));
+        await socket.ConnectAsync(new IPEndPoint(IPAddress.Loopback, (directForward.ListenEndPoint as IPEndPoint)!.Port));
     }
 }

--- a/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
+++ b/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
@@ -90,7 +90,7 @@ namespace Tmds.Ssh
     public delegate bool LocalFileEntryPredicate(ref Tmds.Ssh.LocalFileEntry entry);
     public sealed class LocalForward : System.IDisposable
     {
-        public System.Net.EndPoint LocalEndPoint { get; }
+        public System.Net.EndPoint ListenEndPoint { get; }
         public System.Threading.CancellationToken Stopped { get; }
         public void Dispose() { }
         public void ThrowIfStopped() { }
@@ -150,7 +150,7 @@ namespace Tmds.Ssh
     public class RemoteEndPoint { }
     public sealed class RemoteForward : System.IDisposable
     {
-        public Tmds.Ssh.RemoteEndPoint RemoteEndPoint { get; }
+        public Tmds.Ssh.RemoteEndPoint ListenEndPoint { get; }
         public System.Threading.CancellationToken Stopped { get; }
         public void Dispose() { }
         public void ThrowIfStopped() { }
@@ -387,7 +387,7 @@ namespace Tmds.Ssh
     public delegate T SftpFileEntryTransform<T>(ref Tmds.Ssh.SftpFileEntry entry);
     public sealed class SocksForward : System.IDisposable
     {
-        public System.Net.EndPoint LocalEndPoint { get; }
+        public System.Net.EndPoint ListenEndPoint { get; }
         public System.Threading.CancellationToken Stopped { get; }
         public void Dispose() { }
         public void ThrowIfStopped() { }

--- a/test/Tmds.Ssh.Tests/RemoteForwardTests.cs
+++ b/test/Tmds.Ssh.Tests/RemoteForwardTests.cs
@@ -52,7 +52,7 @@ public class RemoteForwardTests
         byte[] receiveBuffer = new byte[128];
         for (int i = 0; i < 2; i++)
         {
-            RemoteEndPoint endPoint = remoteForward.RemoteEndPoint;
+            RemoteEndPoint endPoint = remoteForward.ListenEndPoint;
             SshDataStream? clientStream = null;
             if (endPoint is RemoteIPListenEndPoint ipEndPoint)
             {
@@ -92,7 +92,7 @@ public class RemoteForwardTests
 
         using var remoteForward = await client.StartRemoteForwardAsync(new RemoteIPListenEndPoint("localhost", 0), new IPEndPoint(IPAddress.Loopback, 5000));
         CancellationToken ct = remoteForward.Stopped;
-        RemoteIPListenEndPoint? endPoint = remoteForward.RemoteEndPoint as RemoteIPListenEndPoint;
+        RemoteIPListenEndPoint? endPoint = remoteForward.ListenEndPoint as RemoteIPListenEndPoint;
 
         Assert.False(ct.IsCancellationRequested);
         Assert.NotNull(endPoint);
@@ -100,7 +100,7 @@ public class RemoteForwardTests
         remoteForward.Dispose();
 
         Assert.True(ct.IsCancellationRequested);
-        Assert.Throws<ObjectDisposedException>(() => remoteForward.RemoteEndPoint);
+        Assert.Throws<ObjectDisposedException>(() => remoteForward.ListenEndPoint);
         Assert.Throws<ObjectDisposedException>(() => remoteForward.Stopped);
         Assert.Throws<ObjectDisposedException>(() => remoteForward.ThrowIfStopped());
 
@@ -114,7 +114,7 @@ public class RemoteForwardTests
 
         using var remoteForward = await client.StartRemoteForwardAsync(new RemoteIPListenEndPoint("localhost", 0), new IPEndPoint(IPAddress.Loopback, 5000));
         CancellationToken ct = remoteForward.Stopped;
-        RemoteIPListenEndPoint? endPoint = remoteForward.RemoteEndPoint as RemoteIPListenEndPoint;
+        RemoteIPListenEndPoint? endPoint = remoteForward.ListenEndPoint as RemoteIPListenEndPoint;
 
         Assert.False(ct.IsCancellationRequested);
         Assert.NotNull(endPoint);
@@ -122,7 +122,7 @@ public class RemoteForwardTests
         client.Dispose();
 
         Assert.True(ct.IsCancellationRequested);
-        Assert.NotNull(remoteForward.RemoteEndPoint);
+        Assert.NotNull(remoteForward.ListenEndPoint);
         Assert.True(remoteForward.Stopped.IsCancellationRequested);
         Assert.Throws<SshConnectionClosedException>(() => remoteForward.ThrowIfStopped());
     }


### PR DESCRIPTION
This is for consistency with 'RemoteListener'.