### PR TITLE
SftpClient: allow SSH_FXP_VERSION extension data to be non-UTF8.

### DIFF
--- a/src/Tmds.Ssh/SftpChannel.Reader.cs
+++ b/src/Tmds.Ssh/SftpChannel.Reader.cs
@@ -40,12 +40,7 @@ partial class SftpChannel
         }
 
         public string ReadString()
-        {
-            int length = ReadInt();
-            string value = s_utf8Encoding.GetString(_remainder.Slice(0, length));
-            _remainder = _remainder.Slice(length);
-            return value;
-        }
+            => s_utf8Encoding.GetString(ReadStringAsSpan());
 
         public void SkipString()
         {
@@ -59,14 +54,16 @@ partial class SftpChannel
             _remainder = _remainder.Slice(length);
         }
 
-        public byte[] ReadStringAsByteArray()
+        public ReadOnlySpan<byte> ReadStringAsSpan()
         {
             int length = ReadInt();
-            byte[] value = new byte[length];
-            _remainder.Slice(0, length).CopyTo(value);
+            ReadOnlySpan<byte> value = _remainder.Slice(0, length);
             _remainder = _remainder.Slice(length);
             return value;
         }
+
+        public byte[] ReadStringAsByteArray()
+            => ReadStringAsSpan().ToArray();
 
         public byte ReadByte()
         {

--- a/src/Tmds.Ssh/SftpChannel.cs
+++ b/src/Tmds.Ssh/SftpChannel.cs
@@ -1438,14 +1438,12 @@ sealed partial class SftpChannel : IDisposable
         SftpExtension supportedExtensions = default;
         while (!reader.Remainder.IsEmpty)
         {
-            string extensionName = reader.ReadString();
-            string extensionData = reader.ReadString();
+            ReadOnlySpan<byte> extensionName = reader.ReadStringAsSpan();
+            ReadOnlySpan<byte> extensionData = reader.ReadStringAsSpan();
 
-            switch (extensionName, extensionData)
+            if (extensionName.SequenceEqual("copy-data"u8) && extensionData.SequenceEqual("1"u8))
             {
-                case ("copy-data", "1"):
-                    supportedExtensions |= SftpExtension.CopyData;
-                    break;
+                supportedExtensions |= SftpExtension.CopyData;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/tmds/Tmds.Ssh/issues/356#issuecomment-2669147591.