### PR TITLE
Remove obsolete members.

### DIFF
--- a/src/Tmds.Ssh/HostKey.cs
+++ b/src/Tmds.Ssh/HostKey.cs
@@ -9,9 +9,6 @@ public sealed partial class HostKey
     public PublicKey Key { get; }
     public HostCertificateInfo? CertificateInfo { get; }
 
-    [Obsolete($"Call {nameof(Key)}.{nameof(Key.SHA256FingerPrint)} instead.")]
-    public string SHA256FingerPrint => Key.SHA256FingerPrint;
-
     internal Name ReceivedKeyType { get; }
     internal PublicKeyAlgorithm PublicKey { get; }
 

--- a/src/Tmds.Ssh/SftpClient.cs
+++ b/src/Tmds.Ssh/SftpClient.cs
@@ -326,10 +326,6 @@ public sealed partial class SftpClient : ISftpDirectory, IDisposable
         return await dir.GetLinkTargetAsync(linkPath, cancellationToken).ConfigureAwait(false);
     }
 
-    [Obsolete($"Use {nameof(GetRealPathAsync)} instead.")]
-    public ValueTask<string> GetFullPathAsync(string path, CancellationToken cancellationToken = default)
-        => GetRealPathAsync(path, cancellationToken);
-
     public async ValueTask<string> GetRealPathAsync(string path, CancellationToken cancellationToken = default)
     {
         var dir = await GetWorkingDirectoryAsync(cancellationToken).ConfigureAwait(false);

--- a/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
+++ b/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
@@ -76,8 +76,6 @@ namespace Tmds.Ssh
     {
         public Tmds.Ssh.HostCertificateInfo? CertificateInfo { get; }
         public Tmds.Ssh.PublicKey Key { get; }
-        [System.Obsolete("Call Key.SHA256FingerPrint instead.")]
-        public string SHA256FingerPrint { get; }
     }
     public interface ISftpDirectory
     {
@@ -292,8 +290,6 @@ namespace Tmds.Ssh
         public System.Threading.Tasks.ValueTask<Tmds.Ssh.FileEntryAttributes?> GetAttributesAsync(string path, bool followLinks, string[]? filter, System.Threading.CancellationToken cancellationToken = default) { }
         public Tmds.Ssh.SftpDirectory GetDirectory(string path) { }
         public System.Collections.Generic.IAsyncEnumerable<T> GetDirectoryEntriesAsync<T>(string path, Tmds.Ssh.SftpFileEntryTransform<T> transform, Tmds.Ssh.EnumerationOptions? options = null) { }
-        [System.Obsolete("Use GetRealPathAsync instead.")]
-        public System.Threading.Tasks.ValueTask<string> GetFullPathAsync(string path, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<string> GetLinkTargetAsync(string linkPath, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<string> GetRealPathAsync(string path, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Tmds.Ssh.SftpFile?> OpenFileAsync(string path, System.IO.FileAccess access, Tmds.Ssh.FileOpenOptions? options, System.Threading.CancellationToken cancellationToken = default) { }


### PR DESCRIPTION
These APIs have been obsolete since 0.13.0.
Removing them for 0.16.0.