### PR TITLE
Use BCL MLKem

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,7 @@
   <ItemGroup>
     <!-- Tmds.Ssh dependencies -->
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.5.1" />
+    <PackageVersion Include="Microsoft.Bcl.Cryptography" Version="10.0.0-preview.5.25277.114" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tmds.Ssh/Tmds.Ssh.csproj
+++ b/src/Tmds.Ssh/Tmds.Ssh.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
@@ -20,6 +20,10 @@
   <ItemGroup>
     <PackageReference Include="BouncyCastle.Cryptography" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0')) ">
+    <PackageReference Include="Microsoft.Bcl.Cryptography" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
.NET 10 adds ML-Kem to BCL. For lower targets, it adds support from [Microsoft.Bcl.Cryptography](https://www.nuget.org/packages/Microsoft.Bcl.Cryptography/) nuget package.

See https://github.com/dotnet/runtime/issues/113508