### PR TITLE
{Download/Upload}EntriesOptions: change RecurseSubdirectories to IncludeSubdirectories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ class DownloadEntriesOptions
   delegate ReadOnlySpan<char> ReplaceCharacters(ReadOnlySpan<char> invalidPath, ReadOnlySpan<char> invalidChars, Span<char> buffer);
 
   bool Overwrite { get; set; } = false;
-  bool RecurseSubdirectories { get; set; } = true;
+  bool IncludeSubdirectories { get; set; } = true;
   bool FollowFileLinks { get; set; } = true;
   bool FollowDirectoryLinks { get; set; } = true;
   UnixFileTypeFilter FileTypeFilter { get; set; } = RegularFile | Directory | SymbolicLink;
@@ -491,7 +491,7 @@ class DownloadEntriesOptions
 class UploadEntriesOptions
 {
   bool Overwrite { get; set; } = false;
-  bool RecurseSubdirectories { get; set; } = true;
+  bool IncludeSubdirectories { get; set; } = true;
   bool FollowFileLinks { get; set; } = true;
   bool FollowDirectoryLinks { get; set; } = true;
   LocalFileEntryPredicate? ShouldRecurse { get; set; }

--- a/src/Tmds.Ssh/DownloadEntriesOptions.cs
+++ b/src/Tmds.Ssh/DownloadEntriesOptions.cs
@@ -8,7 +8,7 @@ public sealed class DownloadEntriesOptions
     public delegate ReadOnlySpan<char> ReplaceCharacters(ReadOnlySpan<char> invalidPath, ReadOnlySpan<char> invalidChars, Span<char> buffer);
 
     public bool Overwrite { get; set; } = false;
-    public bool RecurseSubdirectories { get; set; } = true;
+    public bool IncludeSubdirectories { get; set; } = true;
     public bool FollowFileLinks { get; set; } = true;
     public bool FollowDirectoryLinks { get; set; } = true;
     public UnixFileTypeFilter FileTypeFilter { get; set; } =

--- a/src/Tmds.Ssh/UploadEntriesOptions.cs
+++ b/src/Tmds.Ssh/UploadEntriesOptions.cs
@@ -6,7 +6,7 @@ namespace Tmds.Ssh;
 public sealed class UploadEntriesOptions
 {
     public bool Overwrite { get; set; } = false;
-    public bool RecurseSubdirectories { get; set; } = true;
+    public bool IncludeSubdirectories { get; set; } = true;
     public bool FollowFileLinks { get; set; } = true;
     public bool FollowDirectoryLinks { get; set; } = true;
     public LocalFileEntryPredicate? ShouldRecurse { get; set; }

--- a/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
+++ b/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
@@ -13,8 +13,8 @@ namespace Tmds.Ssh
         public Tmds.Ssh.UnixFileTypeFilter FileTypeFilter { get; set; }
         public bool FollowDirectoryLinks { get; set; }
         public bool FollowFileLinks { get; set; }
+        public bool IncludeSubdirectories { get; set; }
         public bool Overwrite { get; set; }
-        public bool RecurseSubdirectories { get; set; }
         public Tmds.Ssh.DownloadEntriesOptions.ReplaceCharacters ReplaceInvalidCharacters { get; set; }
         public Tmds.Ssh.SftpFileEntryPredicate? ShouldInclude { get; set; }
         public Tmds.Ssh.SftpFileEntryPredicate? ShouldRecurse { get; set; }
@@ -700,8 +700,8 @@ namespace Tmds.Ssh
         public UploadEntriesOptions() { }
         public bool FollowDirectoryLinks { get; set; }
         public bool FollowFileLinks { get; set; }
+        public bool IncludeSubdirectories { get; set; }
         public bool Overwrite { get; set; }
-        public bool RecurseSubdirectories { get; set; }
         public Tmds.Ssh.LocalFileEntryPredicate? ShouldRecurse { get; set; }
     }
 }


### PR DESCRIPTION
It doesn't make sense to create empty directories when RecurseSubdirectories is set to false. This renames it to IncludeSubdirectories and when set to false, it doesn't create empty directories.