### PR TITLE
SshDataStream, RemoteProcess.{StandardInputStream/StandardOutputStream}: only wrap SshExceptions in IOException.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Tmds.Ssh
 
-`Tmds.Ssh` is a modern, managed .NET SSH client library for .NET 6+.
+Tmds.Ssh is a modern, managed .NET SSH client library for .NET 6+.
 
 Documentation: https://tmds.github.io/Tmds.Ssh
 

--- a/src/Tmds.Ssh/ISshChannel.cs
+++ b/src/Tmds.Ssh/ISshChannel.cs
@@ -13,14 +13,15 @@ interface ISshChannel
     void Abort(Exception exception);
 
     ValueTask<(ChannelReadType ReadType, int BytesRead)> ReadAsync
-            (Memory<byte>? stdoutBuffer = default,
-             Memory<byte>? stderrBuffer = default,
-            CancellationToken cancellationToken = default);
+            (Memory<byte>? stdoutBuffer,
+             Memory<byte>? stderrBuffer,
+            CancellationToken cancellationToken,
+            bool forStream = false);
 
-    ValueTask WriteAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken = default);
-    void WriteEof(bool noThrow = false);
+    ValueTask WriteAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken, bool forStream = false);
+    void WriteEof(bool noThrow, bool forStream);
     bool ChangeTerminalSize(int width, int height);
     bool SendSignal(string signalName);
 
-    Exception CreateCloseException();
+    SshException CreateCloseException();
 }

--- a/src/Tmds.Ssh/README.md
+++ b/src/Tmds.Ssh/README.md
@@ -1,4 +1,4 @@
-`Tmds.Ssh` is a modern, open-source SSH client library.
+Tmds.Ssh is a modern, open-source SSH client library.
 
 Documentation: https://tmds.github.io/Tmds.Ssh
 Release notes: https://github.com/tmds/Tmds.Ssh/releases

--- a/src/Tmds.Ssh/SftpChannel.cs
+++ b/src/Tmds.Ssh/SftpChannel.cs
@@ -1585,7 +1585,7 @@ sealed partial class SftpChannel : IDisposable
             {
                 try
                 {
-                    await _channel.WriteAsync(packet.Data).ConfigureAwait(false);
+                    await _channel.WriteAsync(packet.Data, cancellationToken: default).ConfigureAwait(false);
                 }
                 catch
                 {

--- a/src/Tmds.Ssh/SshSession.cs
+++ b/src/Tmds.Ssh/SshSession.cs
@@ -761,7 +761,7 @@ sealed partial class SshSession
         throw CreateCloseException();
     }
 
-    internal Exception CreateCloseException()
+    internal SshException CreateCloseException()
     {
         if (_abortReason == null)
         {

--- a/src/docfx/index.md
+++ b/src/docfx/index.md
@@ -1,4 +1,4 @@
-`Tmds.Ssh` is a modern, open-source SSH client library for .NET.
+Tmds.Ssh is a modern, open-source SSH client library for .NET.
 
 ## Getting Started
 

--- a/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
+++ b/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
@@ -242,7 +242,7 @@ namespace Tmds.Ssh
         public System.IO.Stream StandardInputStream { get; }
         public System.IO.StreamWriter StandardInputWriter { get; }
         public void Dispose() { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachine(typeof(Tmds.Ssh.RemoteProcess.<ReadAllLinesAsync>d__52))]
+        [System.Runtime.CompilerServices.AsyncIteratorStateMachine(typeof(Tmds.Ssh.RemoteProcess.<ReadAllLinesAsync>d__53))]
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "isError",
                 "line"})]


### PR DESCRIPTION
Fixes regression from https://github.com/tmds/Tmds.Ssh/pull/432.