### PR TITLE
HMac: use constant-time comparison.

### DIFF
--- a/src/Tmds.Ssh/HMac.cs
+++ b/src/Tmds.Ssh/HMac.cs
@@ -49,7 +49,7 @@ sealed class HMac : IHMac
         Debug.Assert(bytesWritten == _hash.Length);
 
         Span<byte> expected = _hash.AsSpan().Slice(0, HashSize);
-        return expected.SequenceEqual(hash);
+        return CryptographicOperations.FixedTimeEquals(expected, hash);
     }
 
     internal sealed class HMacNone : IHMac


### PR DESCRIPTION
This is a defensive change.

SSH connections are terminated on HMAC failure and keys are derived for each connection.