### PR TITLE
fix(sftp): truncate overwritten remote file when upload source is smaller

### DIFF
--- a/src/Tmds.Ssh/SftpChannel.cs
+++ b/src/Tmds.Ssh/SftpChannel.cs
@@ -958,12 +958,16 @@ sealed partial class SftpChannel : IDisposable
             throw new SftpException(SftpError.NoSuchFile);
         }
 
+        ValueTask<long> initialLengthTask = overwrite ? remoteFile.GetLengthAsync(cancellationToken) : ValueTask.FromResult(0L);
+
         // Pipeline the writes when the source is a sync, seekable Stream.
         // Treat length zero separately because some Linux file systems (like procfs) have zero lengths for files that are not empty.
         bool pipelineSyncWrites = source.CanSeek && IsSyncStream(source) && source.Length > 0;
 
         if (!pipelineSyncWrites)
         {
+            long initialLength = await initialLengthTask.ConfigureAwait(false);
+
             await s_uploadBufferSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
@@ -972,6 +976,11 @@ sealed partial class SftpChannel : IDisposable
             finally
             {
                 s_uploadBufferSemaphore.Release();
+            }
+
+            if (initialLength > remoteFile.Position)
+            {
+                await remoteFile.SetLengthAsync(remoteFile.Position).ConfigureAwait(false);
             }
 
             await remoteFile.CloseAsync(cancellationToken).ConfigureAwait(false);
@@ -1000,6 +1009,13 @@ sealed partial class SftpChannel : IDisposable
             try
             {
                 await previous.ConfigureAwait(false);
+
+                // Truncate if the remote file is larger than what we've written.
+                long initialLength = await initialLengthTask.ConfigureAwait(false);
+                if (initialLength > length.Value)
+                {
+                    await remoteFile.SetLengthAsync(length.Value).ConfigureAwait(false);
+                }
 
                 await remoteFile.CloseAsync(cancellationToken).ConfigureAwait(false);
             }

--- a/src/Tmds.Ssh/SftpChannel.cs
+++ b/src/Tmds.Ssh/SftpChannel.cs
@@ -952,13 +952,14 @@ sealed partial class SftpChannel : IDisposable
 
     public async ValueTask UploadFileAsync(string workingDirectory, Stream source, string remotePath, long? length, bool overwrite, UnixFilePermissions permissions, CancellationToken cancellationToken)
     {
-        using SftpFile? remoteFile = (await OpenFileCoreAsync(workingDirectory, remotePath, (overwrite ? SftpOpenFlags.OpenOrCreate : SftpOpenFlags.CreateNew) | SftpOpenFlags.Write, permissions, SftpClient.DefaultFileOpenOptions, cancellationToken).ConfigureAwait(false));
+        SftpOpenFlags openFlags = overwrite
+            ? SftpOpenFlags.OpenOrCreate | SftpOpenFlags.Truncate
+            : SftpOpenFlags.CreateNew;
+        using SftpFile? remoteFile = (await OpenFileCoreAsync(workingDirectory, remotePath, openFlags | SftpOpenFlags.Write, permissions, SftpClient.DefaultFileOpenOptions, cancellationToken).ConfigureAwait(false));
         if (remoteFile is null)
         {
             throw new SftpException(SftpError.NoSuchFile);
         }
-
-        ValueTask<long> initialLengthTask = overwrite ? remoteFile.GetLengthAsync(cancellationToken) : ValueTask.FromResult(0L);
 
         // Pipeline the writes when the source is a sync, seekable Stream.
         // Treat length zero separately because some Linux file systems (like procfs) have zero lengths for files that are not empty.
@@ -966,8 +967,6 @@ sealed partial class SftpChannel : IDisposable
 
         if (!pipelineSyncWrites)
         {
-            long initialLength = await initialLengthTask.ConfigureAwait(false);
-
             await s_uploadBufferSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
@@ -976,11 +975,6 @@ sealed partial class SftpChannel : IDisposable
             finally
             {
                 s_uploadBufferSemaphore.Release();
-            }
-
-            if (initialLength > remoteFile.Position)
-            {
-                await remoteFile.SetLengthAsync(remoteFile.Position).ConfigureAwait(false);
             }
 
             await remoteFile.CloseAsync(cancellationToken).ConfigureAwait(false);
@@ -1009,13 +1003,6 @@ sealed partial class SftpChannel : IDisposable
             try
             {
                 await previous.ConfigureAwait(false);
-
-                // Truncate if the remote file is larger than what we've written.
-                long initialLength = await initialLengthTask.ConfigureAwait(false);
-                if (initialLength > length.Value)
-                {
-                    await remoteFile.SetLengthAsync(length.Value).ConfigureAwait(false);
-                }
 
                 await remoteFile.CloseAsync(cancellationToken).ConfigureAwait(false);
             }


### PR DESCRIPTION
Fixes [SftpClient.UploadFileAsync(..., overwrite: true)](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) behavior when replacing an existing remote file with smaller source content.

Previously, overwrite wrote from offset 0 but could leave stale trailing bytes from the previous remote file if the new source was shorter.