### PR TITLE
Reduce allocations.

### DIFF
--- a/src/Tmds.Ssh/RemoteProcess.cs
+++ b/src/Tmds.Ssh/RemoteProcess.cs
@@ -50,9 +50,17 @@ public sealed class RemoteProcess : IDisposable
         {
             if (_charBuffer == null)
             {
-                // TODO: alloc from ArrayPool?
-                _charBuffer = new char[encoding.GetMaxCharCount(BufferSize)];
+                _charBuffer = ArrayPool<char>.Shared.Rent(encoding.GetMaxCharCount(BufferSize));
                 _decoder = encoding.GetDecoder();
+            }
+        }
+
+        public void ReturnBuffer()
+        {
+            if (_charBuffer != null)
+            {
+                ArrayPool<char>.Shared.Return(_charBuffer);
+                _charBuffer = null!;
             }
         }
 
@@ -842,8 +850,7 @@ public sealed class RemoteProcess : IDisposable
 
         if (_byteBuffer == null)
         {
-            // TODO: alloc from ArrayPool?
-            _byteBuffer = new byte[BufferSize];
+            _byteBuffer = ArrayPool<byte>.Shared.Rent(BufferSize);
             if (readStdout)
             {
                 _stdoutBuffer.Initialize(_standardOutputEncoding);
@@ -880,6 +887,13 @@ public sealed class RemoteProcess : IDisposable
     public void Dispose()
     {
         _readMode = ReadMode.Disposed;
+        if (_byteBuffer != null)
+        {
+            ArrayPool<byte>.Shared.Return(_byteBuffer);
+            _byteBuffer = null;
+        }
+        _stdoutBuffer.ReturnBuffer();
+        _stderrBuffer.ReturnBuffer();
         _channel.Dispose();
     }
 
@@ -955,8 +969,7 @@ public sealed class RemoteProcess : IDisposable
             _stderrHandler = stderrHandler;
             if (_stderrHandler != null)
             {
-                // TODO: alloc from ArrayPool?
-                _stderrBuffer = new byte[BufferSize];
+                _stderrBuffer = ArrayPool<byte>.Shared.Rent(BufferSize);
             }
         }
 
@@ -1071,6 +1084,10 @@ public sealed class RemoteProcess : IDisposable
                 if (disposing)
                 {
                     _stderrHandler?.Dispose();
+                    if (_stderrBuffer != null)
+                    {
+                        ArrayPool<byte>.Shared.Return(_stderrBuffer);
+                    }
                 }
                 _disposed = true;
             }

--- a/src/Tmds.Ssh/SftpChannel.Writer.cs
+++ b/src/Tmds.Ssh/SftpChannel.Writer.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Diagnostics;
 using System.Text;
 
 namespace Tmds.Ssh;
@@ -225,17 +226,45 @@ partial class SftpChannel
         await ExecuteAsync<object?>(packet, id, pendingOperation, cancellationToken).ConfigureAwait(false);
     }
 
+    private ValueTask<int> ExecuteIntAsync(
+        Packet packet,
+        int id,
+        PendingOperation pendingOperation,
+        CancellationToken cancellationToken)
+    {
+        QueueOperation(packet, id, pendingOperation, cancellationToken);
+
+        return new ValueTask<int>(pendingOperation, pendingOperation.Token);
+    }
+
     private async ValueTask<T> ExecuteAsync<T>(
         Packet packet,
         int id,
         PendingOperation? pendingOperation,
         CancellationToken cancellationToken)
     {
-        CancellationTokenRegistration ctr;
+        Debug.Assert(typeof(T) != typeof(int), "Use ExecuteIntAsync for int return type.");
 
+        QueueOperation(packet, id, pendingOperation, cancellationToken);
+
+        if (pendingOperation is null)
+        {
+            return default!;
+        }
+
+        object? result = await new ValueTask<object?>(pendingOperation, pendingOperation.Token).ConfigureAwait(false);
+        return (T)result!;
+    }
+
+    private void QueueOperation(
+        Packet packet,
+        int id,
+        PendingOperation? pendingOperation,
+        CancellationToken cancellationToken)
+    {
         if (pendingOperation is not null)
         {
-            ctr = pendingOperation.RegisterForCancellation(cancellationToken);
+            pendingOperation.RegisterForCancellation(cancellationToken);
 
             // Track the pending operation before queueing the send.
             _pendingOperations[id] = pendingOperation;
@@ -251,22 +280,6 @@ partial class SftpChannel
             {
                 pendingOperation?.HandleClose();
             }
-        }
-
-        if (pendingOperation is null)
-        {
-            return default!;
-        }
-
-        if (typeof(T) == typeof(int))
-        {
-            int result = await new ValueTask<int>(pendingOperation, pendingOperation.Token).ConfigureAwait(false);
-            return (T)(object)result;
-        }
-        else
-        {
-            object? result = await new ValueTask<object?>(pendingOperation, pendingOperation.Token).ConfigureAwait(false);
-            return (T)result!;
         }
     }
 }

--- a/src/Tmds.Ssh/SftpChannel.cs
+++ b/src/Tmds.Ssh/SftpChannel.cs
@@ -2,6 +2,7 @@
 // See file LICENSE for full license details.
 
 using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
 using System.Buffers;
@@ -1566,11 +1567,18 @@ sealed partial class SftpChannel : IDisposable
         return packetBuffer;
     }
 
+    internal static void ReturnStolenBuffer(byte[] buffer)
+    {
+        // Safe to call with Array.Empty<byte>() (EOF marker) — ArrayPool ignores zero-length returns.
+        ArrayPool<byte>.Shared.Return(buffer);
+    }
+
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
     private async ValueTask<ReadOnlyMemory<byte>> ReadPacketAsync(CancellationToken cancellationToken)
     {
         if (_packetBuffer is null)
         {
-            _packetBuffer = new byte[_receiveBufferSize]; // TODO: rent from shared pool.
+            _packetBuffer = ArrayPool<byte>.Shared.Rent(_receiveBufferSize);
         }
         int totalReceived = 0;
 
@@ -1602,7 +1610,8 @@ sealed partial class SftpChannel : IDisposable
 
             // _receiveBufferSize changed since we've allocated the buffer.
             // Reallocate the buffer to match the new size.
-            _packetBuffer = new byte[_receiveBufferSize];
+            ArrayPool<byte>.Shared.Return(_packetBuffer);
+            _packetBuffer = ArrayPool<byte>.Shared.Rent(_receiveBufferSize);
         }
 
         // Read packet.
@@ -1663,6 +1672,13 @@ sealed partial class SftpChannel : IDisposable
         }
         finally
         {
+            // Return pooled packet buffer.
+            if (_packetBuffer is not null)
+            {
+                ArrayPool<byte>.Shared.Return(_packetBuffer);
+                _packetBuffer = null;
+            }
+
             // No additional sends can be queued.
             _pendingSends.Writer.Complete();
 
@@ -1741,7 +1757,7 @@ sealed partial class SftpChannel : IDisposable
         packet.WriteInt64(offset);
         packet.WriteInt(buffer.Length);
 
-        return ExecuteAsync<int>(packet, id, pendingOperation, cancellationToken);
+        return ExecuteIntAsync(packet, id, pendingOperation, cancellationToken);
     }
     internal ValueTask<FileEntryAttributes> GetAttributesForHandleAsync(byte[] handle, string[]? filter, CancellationToken cancellationToken = default)
     {

--- a/src/Tmds.Ssh/SftpFile.cs
+++ b/src/Tmds.Ssh/SftpFile.cs
@@ -116,11 +116,11 @@ public sealed class SftpFile : Stream
     /// <param name="offset">File offset to read from.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     /// <returns>Number of bytes read.</returns>
-    public async ValueTask<int> ReadAtAsync(Memory<byte> buffer, long offset, CancellationToken cancellationToken = default)
+    public ValueTask<int> ReadAtAsync(Memory<byte> buffer, long offset, CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
 
-        return await _channel.ReadFileAsync(Handle, offset, buffer, cancellationToken).ConfigureAwait(false);
+        return _channel.ReadFileAsync(Handle, offset, buffer, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/Tmds.Ssh/SftpFileSystemEnumerable.cs
+++ b/src/Tmds.Ssh/SftpFileSystemEnumerable.cs
@@ -1,6 +1,7 @@
 // This file is part of Tmds.Ssh which is released under MIT.
 // See file LICENSE for full license details.
 
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
 
@@ -37,8 +38,8 @@ sealed class SftpFileSystemEnumerable<T> : IAsyncEnumerable<T>
 
 sealed class EnumeratorContext
 {
-    public readonly char[] PathBuffer = new char[RemotePath.MaxPathLength]; // TODO: pool alloc
-    public readonly char[] NameBuffer = new char[RemotePath.MaxNameLength]; // TODO: pool alloc
+    public readonly char[] PathBuffer = ArrayPool<char>.Shared.Rent(RemotePath.MaxPathLength);
+    public readonly char[] NameBuffer = ArrayPool<char>.Shared.Rent(RemotePath.MaxNameLength);
     public readonly string[]? ExtendedAttributesFilter;
 
     public EnumeratorContext(string[]? extendedAttributesFilter)
@@ -114,6 +115,10 @@ sealed class SftpFileSystemEnumerator<T> : IAsyncEnumerator<T>
         {
             _entriesRemaining = Disposed;
 
+            ReturnReadDirPacket();
+            ArrayPool<char>.Shared.Return(_context.PathBuffer);
+            ArrayPool<char>.Shared.Return(_context.NameBuffer);
+
             if (_fileHandle is not null)
             {
                 _fileHandle.Dispose();
@@ -180,6 +185,7 @@ sealed class SftpFileSystemEnumerator<T> : IAsyncEnumerator<T>
 
         const int CountIndex = 4 /* packet length */ + 1 /* packet type */ + 4 /* id */;
 
+        ReturnReadDirPacket();
         _readDirPacket = await _readAhead.ConfigureAwait(false);
 
         if (_readDirPacket.Length < CountIndex + 4)
@@ -323,6 +329,15 @@ sealed class SftpFileSystemEnumerator<T> : IAsyncEnumerator<T>
         {
             SftpFileEntry entry = new SftpFileEntry(_path, linkEntry.Span, _context, out int _, attributes);
             return SetCurrent(ref entry);
+        }
+    }
+
+    private void ReturnReadDirPacket()
+    {
+        if (_readDirPacket is not null)
+        {
+            SftpChannel.ReturnStolenBuffer(_readDirPacket);
+            _readDirPacket = null;
         }
     }
 }

--- a/src/Tmds.Ssh/SshChannel.cs
+++ b/src/Tmds.Ssh/SshChannel.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 
 namespace Tmds.Ssh;
@@ -82,6 +83,7 @@ sealed partial class SshChannel : ISshChannel
     private bool _closeReceived;
     
 
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
     public async ValueTask<(ChannelReadType ReadType, int BytesRead)> ReadAsync
         (Memory<byte>? stdoutBuffer = default,
         Memory<byte>? stderrBuffer = default,
@@ -463,9 +465,11 @@ sealed partial class SshChannel : ISshChannel
         {
             case MessageId.SSH_MSG_CHANNEL_REQUEST:
                 HandleMsgChannelRequest(packet);
+                packet.Dispose();
                 return; // Don't queue.
             case MessageId.SSH_MSG_CHANNEL_WINDOW_ADJUST:
                 HandleMsgWindowAdjust(packet);
+                packet.Dispose();
                 return; // Don't queue.
 
             case MessageId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION:
@@ -524,6 +528,7 @@ sealed partial class SshChannel : ISshChannel
         }
     }
 
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
     private async ValueTask<Packet> ReceivePacketAsync(CancellationToken ct, bool forStream = false)
     {
         // Allow reading while in the Closed state so we can receive the peer CLOSE message.

--- a/src/Tmds.Ssh/StreamSshConnection.cs
+++ b/src/Tmds.Ssh/StreamSshConnection.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.Extensions.Logging;
 
@@ -111,6 +112,7 @@ sealed class StreamSshConnection : SshConnection
         }
     }
 
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
     private async ValueTask<int> ReceiveAsync(CancellationToken ct)
     {
         var memory = _receiveBuffer.AllocGetMemory(Constants.PreferredBufferSize);
@@ -156,6 +158,7 @@ sealed class StreamSshConnection : SshConnection
         return false;
     }
 
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
     public async override ValueTask<Packet> ReceivePacketAsync(CancellationToken ct, int maxLength)
     {
         while (true)


### PR DESCRIPTION
Use ArrayPool, PoolingAsyncValueTaskMethodBuilder, and eliminate boxing.
Fix leaked packets for channel request and window adjust messages.