### PR TITLE
SftpClient: limit default download/upload concurrency to 1 entry.

### DIFF
--- a/src/Tmds.Ssh/DownloadEntriesOptions.cs
+++ b/src/Tmds.Ssh/DownloadEntriesOptions.cs
@@ -68,6 +68,21 @@ public sealed class DownloadEntriesOptions
     /// </summary>
     public TargetDirectoryCreation TargetDirectoryCreation { get; set; } = TargetDirectoryCreation.CreateWithParents;
 
+    /// <summary>
+    /// Gets or sets the maximum number of concurrent entries. Defaults to <c>1</c>. Must be between <c>1</c> and <c>64</c>.
+    /// </summary>
+    /// <remarks>Increasing this value enables having more files in flight when transferring a lot of small files over high latency connections.</remarks>
+    public int MaxConcurrentEntries
+    {
+        get => field;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, 1);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, SftpChannel.MaxConcurrentTransferEntries);
+            field = value;
+        }
+    } = 1;
+
     private static ReadOnlySpan<char> ReplaceInvalidCharactersWithUnderscore(ReadOnlySpan<char> invalidPath, ReadOnlySpan<char> invalidChars, Span<char> buffer)
     {
         Span<char> path = buffer.Length >= invalidPath.Length ? buffer.Slice(0, invalidPath.Length)

--- a/src/Tmds.Ssh/SftpChannel.cs
+++ b/src/Tmds.Ssh/SftpChannel.cs
@@ -24,7 +24,8 @@ sealed partial class SftpChannel : IDisposable
     // This is the version implemented by OpenSSH.
     const uint ProtocolVersion = 3;
 
-    const int MaxConcurrentTransferOperations = 64;
+    internal const int MaxConcurrentTransferEntries = 64;
+    const int MaxConcurrentDeleteEntries = 128;
     // Limit the number of buffers allocated for copying.
     // An onGoing ValueTask may allocate multiple buffers.
     const int MaxConcurrentBuffers = 64;
@@ -205,11 +206,11 @@ sealed partial class SftpChannel : IDisposable
 
     private async ValueTask DeleteDirectoryWithProgressAsync(string workingDirectory, string path, SftpProgressHandler progress, CancellationToken cancellationToken)
     {
-        progress.CallStart();
+        progress.CallStart(1);
         Exception? completedException = null;
         try
         {
-            progress.CallEntryStart(0, UnixFileType.Directory, new SftpProgressHandler.Entry { SourcePath = path, SourceLength = null });
+            progress.CallEntryStart(0, UnixFileType.Directory, new SftpProgressHandler.Entry(path, sourceLength: null));
             progress.CallEntriesDiscovered();
             int result = await DeleteDirectoryWithResultAsync(workingDirectory, path, cancellationToken).ConfigureAwait(false);
             if (result == (int)SftpError.None)
@@ -235,7 +236,7 @@ sealed partial class SftpChannel : IDisposable
     private async ValueTask DeleteDirectoryEntryWithProgressAsync(string path, SftpDeleteProgressHandler deleteProgress, CancellationToken cancellationToken)
     {
         int entryIndex = deleteProgress.ReserveIndex();
-        deleteProgress.CallEntryStart(entryIndex, UnixFileType.Directory, new SftpProgressHandler.Entry { SourcePath = path, SourceLength = null });
+        deleteProgress.CallEntryStart(entryIndex, UnixFileType.Directory, new SftpProgressHandler.Entry(path, sourceLength: null));
         int result = await DeleteDirectoryWithResultAsync("", path, cancellationToken).ConfigureAwait(false);
         if (result == (int)SftpError.None)
         {
@@ -251,7 +252,7 @@ sealed partial class SftpChannel : IDisposable
     private async ValueTask DeleteFileEntryWithProgressAsync(string path, UnixFileType fileType, SftpDeleteProgressHandler deleteProgress, CancellationToken cancellationToken)
     {
         int entryIndex = deleteProgress.ReserveIndex();
-        deleteProgress.CallEntryStart(entryIndex, fileType, new SftpProgressHandler.Entry { SourcePath = path, SourceLength = null });
+        deleteProgress.CallEntryStart(entryIndex, fileType, new SftpProgressHandler.Entry(path, sourceLength: null));
         int result = await DeleteFileWithResultAsync("", path, cancellationToken).ConfigureAwait(false);
         if (result == (int)SftpError.None)
         {
@@ -267,7 +268,7 @@ sealed partial class SftpChannel : IDisposable
     private async ValueTask DeleteDirectoryRecursiveAsync(string workingDirectory, string path, SftpProgressHandler? progress, CancellationToken cancellationToken = default)
     {
         SftpDeleteProgressHandler? deleteProgress = progress is not null ? new(progress) : null;
-        deleteProgress?.CallStart();
+        deleteProgress?.CallStart(MaxConcurrentDeleteEntries);
         Exception? completedException = null;
         try
         {
@@ -294,7 +295,7 @@ sealed partial class SftpChannel : IDisposable
                     if (deleteProgress is not null)
                     {
                         rootEntryIndex = deleteProgress.ReserveIndex();
-                        deleteProgress.CallEntryStart(rootEntryIndex, UnixFileType.Directory, new SftpProgressHandler.Entry { SourcePath = path, SourceLength = null });
+                        deleteProgress.CallEntryStart(rootEntryIndex, UnixFileType.Directory, new SftpProgressHandler.Entry(path, sourceLength: null));
                         deleteProgress.CallEntriesDiscovered();
                         if (deleteError == (int)SftpError.None)
                         {
@@ -312,6 +313,9 @@ sealed partial class SftpChannel : IDisposable
 
                 var onGoing = new Queue<ValueTask>();
 
+                // To ensure we don't go above the entry limit we can't queue directory deletes as a side-effect of enumerating.
+                Queue<string>? completedDirectories = deleteProgress is not null ? new() : null;
+
                 await using var enumerator = new SftpFileSystemEnumerator<object?>(
                     this,
                     path,
@@ -323,7 +327,7 @@ sealed partial class SftpChannel : IDisposable
                         FollowFileLinks = false,
                         FileTypeFilter = ~UnixFileTypeFilter.Directory,
                         DirectoryCompleted = deleteProgress is not null
-                            ? (ReadOnlySpan<char> dir) => onGoing.Enqueue(DeleteDirectoryEntryWithProgressAsync(new string(dir), deleteProgress, cancellationToken))
+                            ? (ReadOnlySpan<char> dir) => completedDirectories!.Enqueue(new string(dir))
                             : (ReadOnlySpan<char> dir) => onGoing.Enqueue(DeleteDirectoryAsync("", dir, cancellationToken)),
                         ShouldInclude = deleteProgress is not null
                             ? (ref SftpFileEntry entry) => { onGoing.Enqueue(DeleteFileEntryWithProgressAsync(entry.ToPath(), entry.FileType, deleteProgress, cancellationToken)); return true; }
@@ -334,21 +338,31 @@ sealed partial class SftpChannel : IDisposable
 
                 try
                 {
-                    // When the enumerator needs to make a request for additional entries
-                    // delete requests that came before it will have completed.
-                    // This limits the number of on-going delete requests.
                     while (await enumerator.MoveNextAsync().ConfigureAwait(false))
                     {
+                        if (completedDirectories is not null)
+                        {
+                            await EnqueueCompletedDirectoriesAsync(completedDirectories).ConfigureAwait(false);
+                        }
+                        if (onGoing.Count == MaxConcurrentDeleteEntries)
+                        {
+                            await onGoing.Dequeue().ConfigureAwait(false);
+                        }
                         while (onGoing.TryPeek(out ValueTask first) && first.IsCompleted)
                         {
                             await onGoing.Dequeue().ConfigureAwait(false);
                         }
                     }
+                    // Enqueue remaining completed directories.
+                    if (completedDirectories is not null)
+                    {
+                        await EnqueueCompletedDirectoriesAsync(completedDirectories).ConfigureAwait(false);
+                    }
 
                     if (deleteProgress is not null)
                     {
                         rootEntryIndex = deleteProgress.ReserveIndex();
-                        deleteProgress.CallEntryStart(rootEntryIndex, UnixFileType.Directory, new SftpProgressHandler.Entry { SourcePath = path, SourceLength = null });
+                        deleteProgress.CallEntryStart(rootEntryIndex, UnixFileType.Directory, new SftpProgressHandler.Entry(path, sourceLength: null));
                     }
                     deleteProgress?.CallEntriesDiscovered();
                     while (onGoing.TryDequeue(out ValueTask pending))
@@ -366,6 +380,18 @@ sealed partial class SftpChannel : IDisposable
                         }
                         catch
                         { }
+                    }
+                }
+
+                async ValueTask EnqueueCompletedDirectoriesAsync(Queue<string> directories)
+                {
+                    while (directories.TryDequeue(out string? dir))
+                    {
+                        if (onGoing.Count == MaxConcurrentDeleteEntries)
+                        {
+                            await onGoing.Dequeue().ConfigureAwait(false);
+                        }
+                        onGoing.Enqueue(DeleteDirectoryEntryWithProgressAsync(dir, deleteProgress!, cancellationToken));
                     }
                 }
             }
@@ -411,7 +437,7 @@ sealed partial class SftpChannel : IDisposable
 
     public async ValueTask CopyFileAsync(string workingDirectory, string sourcePath, string destinationPath, bool overwrite, SftpProgressHandler? progress, CancellationToken cancellationToken = default)
     {
-        progress?.CallStart();
+        progress?.CallStart(1);
         Exception? completedException = null;
         try
         {
@@ -458,7 +484,7 @@ sealed partial class SftpChannel : IDisposable
 
             long copyLength = (await sourceAttributesTask.ConfigureAwait(false))!.Length;
 
-            progress?.CallEntryStart(index: 0, UnixFileType.RegularFile, new SftpProgressHandler.Entry { SourcePath = sourcePath, SourceLength = copyLength });
+            progress?.CallEntryStart(index: 0, UnixFileType.RegularFile, new SftpProgressHandler.Entry(sourcePath, copyLength));
             progress?.CallEntriesDiscovered();
 
             if (copyLength > 0)
@@ -803,7 +829,7 @@ sealed partial class SftpChannel : IDisposable
 
     private async ValueTask CreateSymbolicLinkAsync(string workingDirectory, string linkPath, string targetPath, bool overwrite, int entryIndex, string sourcePath, SftpProgressHandler progress, CancellationToken cancellationToken)
     {
-        progress.CallEntryStart(entryIndex, UnixFileType.SymbolicLink, new SftpProgressHandler.Entry { SourcePath = sourcePath, SourceLength = null });
+        progress.CallEntryStart(entryIndex, UnixFileType.SymbolicLink, new SftpProgressHandler.Entry(sourcePath, sourceLength: null));
         await CreateSymbolicLinkAsync(workingDirectory, linkPath, targetPath, overwrite, cancellationToken).ConfigureAwait(false);
         progress.CallEntryCompleted(entryIndex, UnixFileType.SymbolicLink);
     }
@@ -828,7 +854,7 @@ sealed partial class SftpChannel : IDisposable
 
     private async ValueTask CreateDirectoryAsync(string workingDirectory, string path, bool createParents, UnixFilePermissions permissions, int entryIndex, string? sourcePath, SftpProgressHandler? progress, CancellationToken cancellationToken)
     {
-        progress?.CallEntryStart(entryIndex, UnixFileType.Directory, new SftpProgressHandler.Entry { SourcePath = sourcePath ?? "", SourceLength = null });
+        progress?.CallEntryStart(entryIndex, UnixFileType.Directory, new SftpProgressHandler.Entry(sourcePath ?? "", sourceLength: null));
 
         // This method doesn't throw if the target directory already exists.
         // We run a SSH_FXP_STAT in parallel with the SSH_FXP_MKDIR to check if the target directory already exists.
@@ -893,7 +919,8 @@ sealed partial class SftpChannel : IDisposable
 
     public async ValueTask UploadDirectoryEntriesAsync(string workingDirectory, string localDirPath, string remoteDirPath, UploadEntriesOptions? options, SftpProgressHandler? progress, CancellationToken cancellationToken = default)
     {
-        progress?.CallStart();
+        int maxConcurrentEntries = options?.MaxConcurrentEntries ?? MaxConcurrentTransferEntries;
+        progress?.CallStart(maxConcurrentEntries);
         Exception? completedException = null;
         try
         {
@@ -1004,7 +1031,7 @@ sealed partial class SftpChannel : IDisposable
 
                 foreach (var item in fse)
                 {
-                    if (onGoing.Count == MaxConcurrentTransferOperations)
+                    if (onGoing.Count == maxConcurrentEntries)
                     {
                         await onGoing.Dequeue().ConfigureAwait(false);
                     }
@@ -1142,7 +1169,7 @@ sealed partial class SftpChannel : IDisposable
     {
         if (singleFile)
         {
-            progress?.CallStart();
+            progress?.CallStart(1);
         }
 
         FileStream? localFile = null;
@@ -1169,7 +1196,7 @@ sealed partial class SftpChannel : IDisposable
 
     public ValueTask UploadFileAsync(string workingDirectory, Stream source, string remotePath, bool overwrite, UnixFilePermissions permissions, SftpProgressHandler? progress, CancellationToken cancellationToken)
     {
-        progress?.CallStart();
+        progress?.CallStart(1);
         return UploadFileCoreAsync(workingDirectory, source, remotePath, length: null, overwrite, permissions, progress, entryIndex: 0, sourcePath: "", singleFile: true, cancellationToken);
     }
 
@@ -1182,7 +1209,7 @@ sealed partial class SftpChannel : IDisposable
             if (!singleFile)
             {
                 Debug.Assert(length is not null);
-                progress?.CallEntryStart(entryIndex, UnixFileType.RegularFile, new SftpProgressHandler.Entry { SourcePath = sourcePath, SourceLength = length });
+                progress?.CallEntryStart(entryIndex, UnixFileType.RegularFile, new SftpProgressHandler.Entry(sourcePath, length));
             }
 
             SftpOpenFlags openFlags = overwrite
@@ -1202,7 +1229,7 @@ sealed partial class SftpChannel : IDisposable
             {
                 if (singleFile)
                 {
-                    progress?.CallEntryStart(entryIndex, UnixFileType.RegularFile, new SftpProgressHandler.Entry { SourcePath = sourcePath, SourceLength = length });
+                    progress?.CallEntryStart(entryIndex, UnixFileType.RegularFile, new SftpProgressHandler.Entry(sourcePath, length));
                     progress?.CallEntriesDiscovered();
                 }
 
@@ -1224,7 +1251,7 @@ sealed partial class SftpChannel : IDisposable
 
                 if (singleFile)
                 {
-                    progress?.CallEntryStart(entryIndex, UnixFileType.RegularFile, new SftpProgressHandler.Entry { SourcePath = sourcePath, SourceLength = length });
+                    progress?.CallEntryStart(entryIndex, UnixFileType.RegularFile, new SftpProgressHandler.Entry(sourcePath, length));
                     progress?.CallEntriesDiscovered();
                 }
 
@@ -1376,7 +1403,8 @@ sealed partial class SftpChannel : IDisposable
 
     public async ValueTask DownloadDirectoryEntriesAsync(string workingDirectory, string remoteDirPath, string localDirPath, DownloadEntriesOptions? options, SftpProgressHandler? progress, CancellationToken cancellationToken = default)
     {
-        progress?.CallStart();
+        int maxConcurrentEntries = options?.MaxConcurrentEntries ?? MaxConcurrentTransferEntries;
+        progress?.CallStart(maxConcurrentEntries);
         Exception? completedException = null;
         try
         {
@@ -1471,7 +1499,7 @@ sealed partial class SftpChannel : IDisposable
             {
                 await foreach (var item in fse.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    if (onGoing.Count == MaxConcurrentTransferOperations)
+                    if (onGoing.Count == maxConcurrentEntries)
                     {
                         await onGoing.Dequeue().ConfigureAwait(false);
                     }
@@ -1479,7 +1507,7 @@ sealed partial class SftpChannel : IDisposable
                     switch (item.Type)
                     {
                         case UnixFileType.Directory:
-                            progress?.CallEntryStart(entryIndex, UnixFileType.Directory, new SftpProgressHandler.Entry { SourcePath = item.RemotePath, SourceLength = null });
+                            progress?.CallEntryStart(entryIndex, UnixFileType.Directory, new SftpProgressHandler.Entry(item.RemotePath, sourceLength: null));
                             bool exists = Directory.Exists(item.LocalPath);
                             if (!exists)
                             {
@@ -1582,7 +1610,7 @@ sealed partial class SftpChannel : IDisposable
 
     private async ValueTask DownloadLinkAsync(string workingDirectory, string remotePath, string localPath, bool overwrite, int entryIndex, SftpProgressHandler? progress, CancellationToken cancellationToken)
     {
-        progress?.CallEntryStart(entryIndex, UnixFileType.SymbolicLink, new SftpProgressHandler.Entry { SourcePath = remotePath, SourceLength = null });
+        progress?.CallEntryStart(entryIndex, UnixFileType.SymbolicLink, new SftpProgressHandler.Entry(remotePath, sourceLength: null));
 
         bool exists =
 #if NET7_0_OR_GREATER
@@ -1608,13 +1636,13 @@ sealed partial class SftpChannel : IDisposable
 
     public ValueTask DownloadFileAsync(string workingDirectory, string remoteFilePath, string localFilePath, bool overwrite, SftpProgressHandler? progress, CancellationToken cancellationToken = default)
     {
-        progress?.CallStart();
+        progress?.CallStart(1);
         return DownloadFileCoreAsync(workingDirectory, remoteFilePath, localFilePath, destination: null, length: null, overwrite, permissions: null, throwIfNotFound: true, progress, entryIndex: 0, remoteFilePath, singleFile: true, cancellationToken);
     }
 
     public ValueTask DownloadFileAsync(string workingDirectory, string remotePath, Stream destination, SftpProgressHandler? progress, CancellationToken cancellationToken = default)
     {
-        progress?.CallStart();
+        progress?.CallStart(1);
         return DownloadFileCoreAsync(workingDirectory, remotePath, localPath: null, destination, length: null, overwrite: false, permissions: null, throwIfNotFound: true, progress, entryIndex: 0, remotePath, singleFile: true, cancellationToken);
     }
 
@@ -1627,7 +1655,7 @@ sealed partial class SftpChannel : IDisposable
             if (!singleFile)
             {
                 Debug.Assert(length is not null);
-                progress?.CallEntryStart(entryIndex, UnixFileType.RegularFile, new SftpProgressHandler.Entry { SourcePath = sourcePath, SourceLength = length });
+                progress?.CallEntryStart(entryIndex, UnixFileType.RegularFile, new SftpProgressHandler.Entry(sourcePath, length));
             }
 
             // Call GetAttributesAsync in parallel with OpenFileAsync.
@@ -1661,7 +1689,7 @@ sealed partial class SftpChannel : IDisposable
 
             if (singleFile)
             {
-                progress?.CallEntryStart(entryIndex, UnixFileType.RegularFile, new SftpProgressHandler.Entry { SourcePath = sourcePath, SourceLength = length });
+                progress?.CallEntryStart(entryIndex, UnixFileType.RegularFile, new SftpProgressHandler.Entry(sourcePath, length));
                 progress?.CallEntriesDiscovered();
             }
 
@@ -2233,7 +2261,7 @@ sealed partial class SftpChannel : IDisposable
             }
         }
 
-        internal void CallStart() => _handler.CallStart();
+        internal void CallStart(int maxConcurrentEntries) => _handler.CallStart(maxConcurrentEntries);
         internal void CallCompleted(Exception? exception) => _handler.CallCompleted(exception);
         internal void CallEntryStart(int index, UnixFileType type, SftpProgressHandler.Entry entry) => _handler.CallEntryStart(index, type, entry);
         internal void CallEntryCompleted(int index, UnixFileType type) => _handler.CallEntryCompleted(index, type);

--- a/src/Tmds.Ssh/SftpProgressHandler.cs
+++ b/src/Tmds.Ssh/SftpProgressHandler.cs
@@ -11,7 +11,7 @@ namespace Tmds.Ssh;
 /// <para><see cref="Start"/> is always called synchronously before the async method returns its <see cref="System.Threading.Tasks.ValueTask"/>. <see cref="Completed"/> is called at the end, including when the operation fails.</para>
 /// <para>Entries are identified by an <c>index</c> parameter. For single-entry operations the index is always 0.
 /// For multi-entry operations, indexes are assigned and reused as entries finish.
-/// The index value is always less than <c>64</c> for upload and download operations. For recursive delete operations, the index range may be larger but is bounded by the number of concurrent delete operations.</para>
+/// The index value is always less than the <c>maxConcurrentEntries</c> argument passed to <see cref="Start"/>.</para>
 /// <para>For each discovered entry, <see cref="EntryStart"/> is called.
 /// <see cref="DataTransferred"/> is called for each chunk of data that is successfully transferred.
 /// When the entry is successfully handled, <see cref="EntryCompleted"/> is called.
@@ -19,12 +19,12 @@ namespace Tmds.Ssh;
 /// <para>After all entries have been discovered, <see cref="EntriesDiscovered"/> is called and no more <see cref="EntryStart"/> calls will follow.</para>
 /// <para><see cref="EntryStart"/> calls are always sequential. <see cref="EntryCompleted"/>, <see cref="EntrySkipped"/>, and <see cref="DataTransferred"/> may be called concurrently for different entries but are sequential for the same entry.</para>
 /// <para>Because <see cref="EntryStart"/> calls are sequential, they can be used to resize an array that tracks per-entry information using the index as position. Each new entry can fill in its information at start. Note that clearing information when an entry finishes may be lost if the array is resized by a concurrent <see cref="EntryStart"/> call.</para>
-/// <para>For per-entry <see cref="DataTransferred"/> information, resizing does not work because it would affect tracking for on-going entries. A fixed-size array of <see cref="MaxConcurrentTransferEntries"/> elements can be used instead.</para>
+/// <para>For per-entry <see cref="DataTransferred"/> information, resizing does not work because it would affect tracking for on-going entries. A fixed-size array of <c>maxConcurrentEntries</c> elements can be used instead.</para>
 /// </remarks>
 public abstract class SftpProgressHandler
 {
     /// <summary>The maximum number of concurrent entries for upload and download operations (64).</summary>
-    public const int MaxConcurrentTransferEntries = 64;
+    public const int MaxConcurrentTransferEntries = SftpChannel.MaxConcurrentTransferEntries;
 
     private long _allocatedIndexes;
 
@@ -59,9 +59,10 @@ public abstract class SftpProgressHandler
     }
 
     /// <summary>Called when the operation starts.</summary>
-    protected virtual void Start() { }
+    /// <param name="maxConcurrentEntries">The upper bound for entry indices used during this operation.</param>
+    protected virtual void Start(int maxConcurrentEntries) { }
 
-    internal void CallStart() => Start();
+    internal void CallStart(int maxConcurrentEntries) => Start(maxConcurrentEntries);
 
     /// <summary>Called when the operation finishes.</summary>
     /// <param name="exception"><see langword="null"/> on success, the exception that caused the operation to fail.</param>
@@ -118,12 +119,21 @@ public abstract class SftpProgressHandler
     internal void CallEntriesDiscovered() => EntriesDiscovered();
 
     /// <summary>Describes an entry being handled.</summary>
-    public readonly struct Entry
+    public readonly ref struct Entry
     {
+        /// <summary>Initializes a new <see cref="Entry"/>.</summary>
+        /// <param name="sourcePath">The source path of the entry.</param>
+        /// <param name="sourceLength">The expected length of the source data, or <see langword="null"/> if unknown.</param>
+        public Entry(string sourcePath, long? sourceLength)
+        {
+            SourcePath = sourcePath;
+            SourceLength = sourceLength;
+        }
+
         /// <summary>The source path of the entry.</summary>
-        public string SourcePath { get; init; }
+        public string SourcePath { get; }
 
         /// <summary>The expected length of the source data, or <see langword="null"/> if unknown.</summary>
-        public long? SourceLength { get; init; }
+        public long? SourceLength { get; }
     }
 }

--- a/src/Tmds.Ssh/UploadEntriesOptions.cs
+++ b/src/Tmds.Ssh/UploadEntriesOptions.cs
@@ -45,4 +45,19 @@ public sealed class UploadEntriesOptions
     /// Gets or sets how to handle target directory creation.
     /// </summary>
     public TargetDirectoryCreation TargetDirectoryCreation { get; set; } = TargetDirectoryCreation.CreateWithParents;
+
+    /// <summary>
+    /// Gets or sets the maximum number of concurrent entries. Defaults to <c>1</c>. Must be between <c>1</c> and <c>64</c>.
+    /// </summary>
+    /// <remarks>Increasing this value enables having more files in flight when transferring a lot of small files over high latency connections.</remarks>
+    public int MaxConcurrentEntries
+    {
+        get => field;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, 1);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, SftpChannel.MaxConcurrentTransferEntries);
+            field = value;
+        }
+    } = 1;
 }

--- a/src/ssh-cp/Program.cs
+++ b/src/ssh-cp/Program.cs
@@ -541,7 +541,7 @@ sealed class ConsoleProgress : SftpProgressHandler
         }
     }
 
-    protected override void Start()
+    protected override void Start(int maxConcurrentEntries)
         => _startTime = Stopwatch.GetTimestamp();
 
     protected override void EntryStart(int index, UnixFileType type, Entry entry)

--- a/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
+++ b/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
@@ -32,6 +32,7 @@ namespace Tmds.Ssh
         public bool FollowDirectoryLinks { get; set; }
         public bool FollowFileLinks { get; set; }
         public bool IncludeSubdirectories { get; set; }
+        public int MaxConcurrentEntries { get; set; }
         public bool Overwrite { get; set; }
         public Tmds.Ssh.DownloadEntriesOptions.ReplaceCharacters ReplaceInvalidCharacters { get; set; }
         public Tmds.Ssh.SftpFileEntryPredicate? ShouldInclude { get; set; }
@@ -480,11 +481,12 @@ namespace Tmds.Ssh
         protected virtual void EntryCompleted(int index, Tmds.Ssh.UnixFileType type) { }
         protected virtual void EntrySkipped(int index, Tmds.Ssh.UnixFileType type) { }
         protected virtual void EntryStart(int index, Tmds.Ssh.UnixFileType type, Tmds.Ssh.SftpProgressHandler.Entry entry) { }
-        protected virtual void Start() { }
-        public readonly struct Entry
+        protected virtual void Start(int maxConcurrentEntries) { }
+        public readonly ref struct Entry
         {
-            public long? SourceLength { get; init; }
-            public string SourcePath { get; init; }
+            public Entry(string sourcePath, long? sourceLength) { }
+            public long? SourceLength { get; }
+            public string SourcePath { get; }
         }
     }
     public static class SignalName
@@ -778,6 +780,7 @@ namespace Tmds.Ssh
         public bool FollowDirectoryLinks { get; set; }
         public bool FollowFileLinks { get; set; }
         public bool IncludeSubdirectories { get; set; }
+        public int MaxConcurrentEntries { get; set; }
         public bool Overwrite { get; set; }
         public Tmds.Ssh.LocalFileEntryPredicate? ShouldInclude { get; set; }
         public Tmds.Ssh.LocalFileEntryPredicate? ShouldRecurse { get; set; }

--- a/test/Tmds.Ssh.Tests/SftpClientTests.cs
+++ b/test/Tmds.Ssh.Tests/SftpClientTests.cs
@@ -211,6 +211,42 @@ public class SftpClientTests
         Assert.Null(attributes);
     }
 
+    [InlineData(false)]
+    [InlineData(true)]
+    [Theory]
+    public async Task DeleteDirectoryRecursiveManyEntries(bool withProgress)
+    {
+        using var sftpClient = await _sshServer.CreateSftpClientAsync();
+
+        string directoryPath = $"/tmp/{Path.GetRandomFileName()}";
+
+        // Create a directory tree 50 levels deep.
+        string deepPath = directoryPath;
+        for (int i = 0; i < 50; i++)
+        {
+            deepPath = $"{deepPath}/d{i}";
+        }
+        await sftpClient.CreateNewDirectoryAsync(deepPath, createParents: true);
+
+        // Create 100 files in the deepest directory.
+        for (int i = 0; i < 100; i++)
+        {
+            using var file = await sftpClient.CreateNewFileAsync($"{deepPath}/file{i}", FileAccess.Write);
+            await file.CloseAsync();
+        }
+
+        var collector = withProgress ? new EventCollector() : null;
+        await sftpClient.DeleteDirectoryAsync(directoryPath, recursive: true, progress: collector);
+
+        var attributes = await sftpClient.GetAttributesAsync(directoryPath);
+        Assert.Null(attributes);
+
+        if (withProgress)
+        {
+            Assert.Equal(128, collector!.MaxConcurrentEntries);
+        }
+    }
+
     [Fact]
     public async Task CreateNewDirectoryThrowsIfExists()
     {
@@ -691,8 +727,10 @@ public class SftpClientTests
         Assert.False(options.RecurseSubdirectories);
     }
 
-    [Fact]
-    public async Task UploadDownloadDirectory()
+    [InlineData(1)] // Default
+    [InlineData(64)] // Max
+    [Theory]
+    public async Task UploadDownloadDirectory(int maxConcurrentEntries)
     {
         using var sftpClient = await _sshServer.CreateSftpClientAsync();
 
@@ -721,10 +759,16 @@ public class SftpClientTests
 
             // Upload
             string remoteDirPath = $"/tmp/{Path.GetRandomFileName()}";
-            await sftpClient.UploadDirectoryEntriesAsync(sourcePath, remoteDirPath);
+            var uploadCollector = new EventCollector();
+            await sftpClient.UploadDirectoryEntriesAsync(sourcePath, remoteDirPath, new UploadEntriesOptions() { MaxConcurrentEntries = maxConcurrentEntries }, progress: uploadCollector);
 
             // Download
-            await sftpClient.DownloadDirectoryEntriesAsync(remoteDirPath, destinationPath);
+            var downloadCollector = new EventCollector();
+            await sftpClient.DownloadDirectoryEntriesAsync(remoteDirPath, destinationPath, new DownloadEntriesOptions() { MaxConcurrentEntries = maxConcurrentEntries }, progress: downloadCollector);
+
+            // Verify maxConcurrentEntries was passed correctly.
+            Assert.Equal(maxConcurrentEntries, uploadCollector.MaxConcurrentEntries);
+            Assert.Equal(maxConcurrentEntries, downloadCollector.MaxConcurrentEntries);
 
             // Verify the download matches the source directory that was uploaded.
             byte[] buffer2 = new byte[PacketSize * 2];
@@ -2209,8 +2253,8 @@ public class SftpClientTests
 
     sealed class EventCollector : SftpProgressHandler
     {
-        public record StartEvent();
-        public record EntryStartEvent(int Index, UnixFileType Type, SftpProgressHandler.Entry Entry);
+        public record StartEvent(int MaxConcurrentEntries);
+        public record EntryStartEvent(int Index, UnixFileType Type, string SourcePath, long? SourceLength);
         public record DataTransferredEvent(int Index, long BytesTransferred, long Offset);
         public record EntriesDiscoveredEvent();
         public record EntrySkippedEvent(int Index, UnixFileType Type);
@@ -2218,21 +2262,32 @@ public class SftpClientTests
         public record CompletedEvent(Exception? Exception);
 
         private readonly List<object> _events = new();
+        private int _maxConcurrentEntries;
 
         public List<object> Events => _events;
+        public int MaxConcurrentEntries => _maxConcurrentEntries;
 
-        protected override void Start()
+        private void AssertIndexInRange(int index)
         {
-            lock (_events) _events.Add(new StartEvent());
+            Assert.True(index >= 0 && index < _maxConcurrentEntries,
+                $"Index {index} is out of range [0, {_maxConcurrentEntries})");
+        }
+
+        protected override void Start(int maxConcurrentEntries)
+        {
+            _maxConcurrentEntries = maxConcurrentEntries;
+            lock (_events) _events.Add(new StartEvent(maxConcurrentEntries));
         }
 
         protected override void EntryStart(int index, UnixFileType type, SftpProgressHandler.Entry entry)
         {
-            lock (_events) _events.Add(new EntryStartEvent(index, type, entry));
+            AssertIndexInRange(index);
+            lock (_events) _events.Add(new EntryStartEvent(index, type, entry.SourcePath, entry.SourceLength));
         }
 
         protected override void DataTransferred(int index, long bytesTransferred, long offset)
         {
+            AssertIndexInRange(index);
             lock (_events) _events.Add(new DataTransferredEvent(index, bytesTransferred, offset));
         }
 
@@ -2243,11 +2298,13 @@ public class SftpClientTests
 
         protected override void EntrySkipped(int index, UnixFileType type)
         {
+            AssertIndexInRange(index);
             lock (_events) _events.Add(new EntrySkippedEvent(index, type));
         }
 
         protected override void EntryCompleted(int index, UnixFileType type)
         {
+            AssertIndexInRange(index);
             lock (_events) _events.Add(new EntryCompletedEvent(index, type));
         }
 


### PR DESCRIPTION
Also update the SftpProgressHandler to be informed of the max concurrency.
And limit concurrency for delete.