### PR TITLE
CopyFileAsync: add special handling for zero-length source files.

### DIFF
--- a/src/Tmds.Ssh/SftpChannel.cs
+++ b/src/Tmds.Ssh/SftpChannel.cs
@@ -510,6 +510,21 @@ sealed partial class SftpChannel : IDisposable
                     await CopyAsync(copyLength, cancellationToken).ConfigureAwait(false);
                 }
             }
+            else
+            {
+                // Treat length zero separately because some Linux file systems (like procfs) have zero lengths for files that are not empty.
+                int bufferSize = Math.Min(GetMaxReadPayload(), GetMaxWritePayload(destinationFile.Handle));
+                await s_downloadBufferSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await CopyToAsync(sourceFile, destinationFile, bufferSize, entryIndex: 0, progress, cancellationToken).ConfigureAwait(false);
+                    copyLength = destinationFile.Position;
+                }
+                finally
+                {
+                    s_downloadBufferSemaphore.Release();
+                }
+            }
 
             // Truncate if the sourceFile is smaller than the destination file's initial length.
             long initialLength = await initialLengthTask.ConfigureAwait(false);

--- a/src/docfx/index.md
+++ b/src/docfx/index.md
@@ -2,7 +2,7 @@
 [![NuGet Downloads](https://img.shields.io/nuget/dt/Tmds.Ssh)](https://www.nuget.org/packages/Tmds.Ssh)
 [![GitHub](https://img.shields.io/badge/GitHub-tmds%2FTmds.Ssh-blue?logo=github)](https://github.com/tmds/Tmds.Ssh)
 [![License](https://img.shields.io/github/license/tmds/Tmds.Ssh)](https://github.com/tmds/Tmds.Ssh/blob/main/LICENSE)
-![.NET](https://img.shields.io/badge/.NET-8.0%20%7C%209.0%20%7C%2010.0-512BD4)
+![.NET](https://img.shields.io/badge/.NET-8.0%20%7C%209.0%20%7C%2010.0%20%7C%2011.0-512BD4)
 
 Tmds.Ssh is a modern, open-source SSH client library for .NET.
 

--- a/test/Tmds.Ssh.Tests/SftpClientTests.cs
+++ b/test/Tmds.Ssh.Tests/SftpClientTests.cs
@@ -1784,6 +1784,43 @@ public class SftpClientTests
         Assert.NotEqual(0, ms.Length);
     }
 
+    [InlineData(false)]
+    [InlineData(true)]
+    [Theory]
+    public async Task CopySpecialZeroLengthFile(bool overwriteLargerDestination)
+    {
+        using var sftpClient = await _sshServer.CreateSftpClientAsync();
+
+        // Verify the source file reports a length of zero.
+        var sourceAttributes = await sftpClient.GetAttributesAsync("/proc/self/mountinfo");
+        Assert.Equal(0, sourceAttributes!.Length);
+
+        string destinationPath;
+        if (overwriteLargerDestination)
+        {
+            (destinationPath, _) = await CreateRemoteFileWithRandomDataAsync(sftpClient, length: 100_000);
+        }
+        else
+        {
+            destinationPath = $"/tmp/{Path.GetRandomFileName()}";
+        }
+
+        await sftpClient.CopyFileAsync("/proc/self/mountinfo", destinationPath, overwrite: overwriteLargerDestination);
+
+        var attributes = await sftpClient.GetAttributesAsync(destinationPath);
+        Assert.NotNull(attributes);
+        Assert.NotEqual(0, attributes.Length);
+
+        if (overwriteLargerDestination)
+        {
+            // Verify length matches a fresh copy (catches truncation issues).
+            string referencePath = $"/tmp/{Path.GetRandomFileName()}";
+            await sftpClient.CopyFileAsync("/proc/self/mountinfo", referencePath);
+            var referenceAttributes = await sftpClient.GetAttributesAsync(referencePath);
+            Assert.Equal(referenceAttributes!.Length, attributes.Length);
+        }
+    }
+
     [Fact]
     public async Task UploadSpecialZeroLengthFile()
     {


### PR DESCRIPTION
Some Linux file systems (like procfs) report a file length of zero for files that actually contain data. The download and upload paths already handle this, but CopyFileAsync skipped copying entirely when the reported length was zero.