### PR TITLE
Expose SSH user authentication banners

### DIFF
--- a/src/Tmds.Ssh/Banner.cs
+++ b/src/Tmds.Ssh/Banner.cs
@@ -6,12 +6,11 @@ namespace Tmds.Ssh;
 /// <summary>
 /// Context for a banner message sent by the server during authentication.
 /// </summary>
-public struct BannerContext
+public struct BannerMessageContext
 {
-    internal BannerContext(string message, string languageTag, SshConnectionInfo connectionInfo)
+    internal BannerMessageContext(string message, SshConnectionInfo connectionInfo)
     {
         Message = message;
-        LanguageTag = languageTag;
         ConnectionInfo = connectionInfo;
     }
 
@@ -19,40 +18,25 @@ public struct BannerContext
     /// Gets the banner message.
     /// </summary>
     /// <remarks>
-    /// The message is under the control of the server. It may be empty, span multiple lines, and
-    /// contain control characters. Treat it as untrusted when displaying it to a user.
+    /// The message may be empty and may span multiple lines. Control characters other than tab,
+    /// carriage return, and newline are replaced by escape sequences, so the message is safe to
+    /// write to a terminal.
     /// </remarks>
     public string Message { get; }
-
-    /// <summary>
-    /// Gets the language tag of the message, as described in RFC 3066. Often empty.
-    /// </summary>
-    public string LanguageTag { get; }
 
     /// <summary>
     /// Gets the SSH connection information.
     /// </summary>
     public SshConnectionInfo ConnectionInfo { get; }
-
-    /// <summary>
-    /// Returns whether batch (non-interactive) mode is enabled.
-    /// </summary>
-    /// <remarks>
-    /// In batch mode the <see cref="BannerHandler"/> delegate mustn't make interactive prompts.
-    /// </remarks>
-    public bool IsBatchMode => ConnectionInfo.IsBatchMode;
 }
 
 /// <summary>
 /// Delegate for handling banner messages sent by the server.
 /// </summary>
-/// <param name="context">The banner context.</param>
-/// <param name="cancellationToken">Token to cancel the operation.</param>
+/// <param name="context">The banner message context.</param>
 /// <remarks>
 /// The server may send a banner at any time after the authentication protocol starts and before
-/// authentication succeeds, and may send several. Authentication does not continue until the
-/// delegate completes, so a delegate that waits for the user also delays the connection. Bear in
-/// mind that <see cref="SshClientSettings.ConnectTimeout"/> bounds the entire authenticated
-/// connect, including time spent in this delegate.
+/// authentication succeeds, and may send several. The next packet is not read until the delegate
+/// returns.
 /// </remarks>
-public delegate ValueTask BannerHandler(BannerContext context, CancellationToken cancellationToken);
+public delegate void BannerMessageHandler(BannerMessageContext context);

--- a/src/Tmds.Ssh/Banner.cs
+++ b/src/Tmds.Ssh/Banner.cs
@@ -39,4 +39,4 @@ public struct BannerMessageContext
 /// authentication succeeds, and may send several. The next packet is not read until the delegate
 /// returns.
 /// </remarks>
-public delegate void BannerMessageHandler(BannerMessageContext context);
+public delegate void BannerHandler(BannerMessageContext context);

--- a/src/Tmds.Ssh/Banner.cs
+++ b/src/Tmds.Ssh/Banner.cs
@@ -1,0 +1,58 @@
+// This file is part of Tmds.Ssh which is released under MIT.
+// See file LICENSE for full license details.
+
+namespace Tmds.Ssh;
+
+/// <summary>
+/// Context for a banner message sent by the server during authentication.
+/// </summary>
+public struct BannerContext
+{
+    internal BannerContext(string message, string languageTag, SshConnectionInfo connectionInfo)
+    {
+        Message = message;
+        LanguageTag = languageTag;
+        ConnectionInfo = connectionInfo;
+    }
+
+    /// <summary>
+    /// Gets the banner message.
+    /// </summary>
+    /// <remarks>
+    /// The message is under the control of the server. It may be empty, span multiple lines, and
+    /// contain control characters. Treat it as untrusted when displaying it to a user.
+    /// </remarks>
+    public string Message { get; }
+
+    /// <summary>
+    /// Gets the language tag of the message, as described in RFC 3066. Often empty.
+    /// </summary>
+    public string LanguageTag { get; }
+
+    /// <summary>
+    /// Gets the SSH connection information.
+    /// </summary>
+    public SshConnectionInfo ConnectionInfo { get; }
+
+    /// <summary>
+    /// Returns whether batch (non-interactive) mode is enabled.
+    /// </summary>
+    /// <remarks>
+    /// In batch mode the <see cref="BannerHandler"/> delegate mustn't make interactive prompts.
+    /// </remarks>
+    public bool IsBatchMode => ConnectionInfo.IsBatchMode;
+}
+
+/// <summary>
+/// Delegate for handling banner messages sent by the server.
+/// </summary>
+/// <param name="context">The banner context.</param>
+/// <param name="cancellationToken">Token to cancel the operation.</param>
+/// <remarks>
+/// The server may send a banner at any time after the authentication protocol starts and before
+/// authentication succeeds, and may send several. Authentication does not continue until the
+/// delegate completes, so a delegate that waits for the user also delays the connection. Bear in
+/// mind that <see cref="SshClientSettings.ConnectTimeout"/> bounds the entire authenticated
+/// connect, including time spent in this delegate.
+/// </remarks>
+public delegate ValueTask BannerHandler(BannerContext context, CancellationToken cancellationToken);

--- a/src/Tmds.Ssh/SshClientSettings.SshConfig.cs
+++ b/src/Tmds.Ssh/SshClientSettings.SshConfig.cs
@@ -57,7 +57,7 @@ partial class SshClientSettings
             KeepAliveInterval = sshConfig.ServerAliveInterval > 0 ? TimeSpan.FromSeconds(sshConfig.ServerAliveInterval.Value) : TimeSpan.Zero,
             Proxy = DetermineProxy(sshConfig.ProxyJump, options),
             BatchMode = sshConfig.BatchMode ?? false,
-            BannerHandler = options.BannerHandler
+            BannerMessageHandler = options.BannerMessageHandler
         };
         if (sshConfig.UserKnownHostsFiles is not null)
         {
@@ -351,7 +351,7 @@ partial class SshClientSettings
                 ConfigFilePaths = configFilePaths,
                 ConnectTimeout = options.ConnectTimeout,
                 HostAuthentication = options.HostAuthentication,
-                BannerHandler = options.BannerHandler
+                BannerMessageHandler = options.BannerMessageHandler
             };
 
             if (!isFirst)

--- a/src/Tmds.Ssh/SshClientSettings.SshConfig.cs
+++ b/src/Tmds.Ssh/SshClientSettings.SshConfig.cs
@@ -56,7 +56,8 @@ partial class SshClientSettings
             KeepAliveCountMax = sshConfig.ServerAliveCountMax ?? DefaultKeepAliveCountMax,
             KeepAliveInterval = sshConfig.ServerAliveInterval > 0 ? TimeSpan.FromSeconds(sshConfig.ServerAliveInterval.Value) : TimeSpan.Zero,
             Proxy = DetermineProxy(sshConfig.ProxyJump, options),
-            BatchMode = sshConfig.BatchMode ?? false
+            BatchMode = sshConfig.BatchMode ?? false,
+            BannerHandler = options.BannerHandler
         };
         if (sshConfig.UserKnownHostsFiles is not null)
         {
@@ -349,7 +350,8 @@ partial class SshClientSettings
             {
                 ConfigFilePaths = configFilePaths,
                 ConnectTimeout = options.ConnectTimeout,
-                HostAuthentication = options.HostAuthentication
+                HostAuthentication = options.HostAuthentication,
+                BannerHandler = options.BannerHandler
             };
 
             if (!isFirst)

--- a/src/Tmds.Ssh/SshClientSettings.SshConfig.cs
+++ b/src/Tmds.Ssh/SshClientSettings.SshConfig.cs
@@ -57,7 +57,7 @@ partial class SshClientSettings
             KeepAliveInterval = sshConfig.ServerAliveInterval > 0 ? TimeSpan.FromSeconds(sshConfig.ServerAliveInterval.Value) : TimeSpan.Zero,
             Proxy = DetermineProxy(sshConfig.ProxyJump, options),
             BatchMode = sshConfig.BatchMode ?? false,
-            BannerMessageHandler = options.BannerMessageHandler
+            BannerHandler = options.BannerHandler
         };
         if (sshConfig.UserKnownHostsFiles is not null)
         {
@@ -351,7 +351,7 @@ partial class SshClientSettings
                 ConfigFilePaths = configFilePaths,
                 ConnectTimeout = options.ConnectTimeout,
                 HostAuthentication = options.HostAuthentication,
-                BannerMessageHandler = options.BannerMessageHandler
+                BannerHandler = options.BannerHandler
             };
 
             if (!isFirst)

--- a/src/Tmds.Ssh/SshClientSettings.cs
+++ b/src/Tmds.Ssh/SshClientSettings.cs
@@ -344,7 +344,7 @@ public sealed partial class SshClientSettings
 
         // Host auth.
         settings.HostAuthentication = HostAuthentication;
-        settings.BannerMessageHandler = BannerMessageHandler;
+        settings.BannerHandler = BannerHandler;
         if (_globalKnownHostsFilePaths is not null)
         {
             settings.GlobalKnownHostsFilePaths = GlobalKnownHostsFilePaths;
@@ -423,13 +423,13 @@ public sealed partial class SshClientSettings
     public HostAuthentication? HostAuthentication { get; set; }
 
     /// <summary>
-    /// Gets or sets the <see cref="Tmds.Ssh.BannerMessageHandler"/> delegate.
+    /// Gets or sets the <see cref="Tmds.Ssh.BannerHandler"/> delegate.
     /// </summary>
     /// <remarks>
     /// When set, the delegate is called for each banner the server sends during authentication.
     /// When unset, banners are ignored.
     /// </remarks>
-    public BannerMessageHandler? BannerMessageHandler { get; set; }
+    public BannerHandler? BannerHandler { get; set; }
 
     /// <summary>
     /// Gets or sets whether to automatically connect when the client is used.

--- a/src/Tmds.Ssh/SshClientSettings.cs
+++ b/src/Tmds.Ssh/SshClientSettings.cs
@@ -344,6 +344,7 @@ public sealed partial class SshClientSettings
 
         // Host auth.
         settings.HostAuthentication = HostAuthentication;
+        settings.BannerHandler = BannerHandler;
         if (_globalKnownHostsFilePaths is not null)
         {
             settings.GlobalKnownHostsFilePaths = GlobalKnownHostsFilePaths;
@@ -420,6 +421,15 @@ public sealed partial class SshClientSettings
     /// This delegate is not called when the host key is known to be trusted or revoked.
     /// </remarks>
     public HostAuthentication? HostAuthentication { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="Tmds.Ssh.BannerHandler"/> delegate.
+    /// </summary>
+    /// <remarks>
+    /// When set, the delegate is called for each banner the server sends during authentication.
+    /// When unset, banners are ignored.
+    /// </remarks>
+    public BannerHandler? BannerHandler { get; set; }
 
     /// <summary>
     /// Gets or sets whether to automatically connect when the client is used.

--- a/src/Tmds.Ssh/SshClientSettings.cs
+++ b/src/Tmds.Ssh/SshClientSettings.cs
@@ -344,7 +344,7 @@ public sealed partial class SshClientSettings
 
         // Host auth.
         settings.HostAuthentication = HostAuthentication;
-        settings.BannerHandler = BannerHandler;
+        settings.BannerMessageHandler = BannerMessageHandler;
         if (_globalKnownHostsFilePaths is not null)
         {
             settings.GlobalKnownHostsFilePaths = GlobalKnownHostsFilePaths;
@@ -423,13 +423,13 @@ public sealed partial class SshClientSettings
     public HostAuthentication? HostAuthentication { get; set; }
 
     /// <summary>
-    /// Gets or sets the <see cref="Tmds.Ssh.BannerHandler"/> delegate.
+    /// Gets or sets the <see cref="Tmds.Ssh.BannerMessageHandler"/> delegate.
     /// </summary>
     /// <remarks>
     /// When set, the delegate is called for each banner the server sends during authentication.
     /// When unset, banners are ignored.
     /// </remarks>
-    public BannerHandler? BannerHandler { get; set; }
+    public BannerMessageHandler? BannerMessageHandler { get; set; }
 
     /// <summary>
     /// Gets or sets whether to automatically connect when the client is used.

--- a/src/Tmds.Ssh/SshConfigSettings.cs
+++ b/src/Tmds.Ssh/SshConfigSettings.cs
@@ -38,7 +38,7 @@ public sealed class SshConfigSettings
     private TimeSpan _connectTimeout = SshClientSettings.DefaultConnectTimeout;
     private HostAuthentication? _hostAuthentication;
     private PasswordPrompt? _passwordPrompt;
-    private BannerHandler? _bannerHandler;
+    private BannerMessageHandler? _bannerMessageHandler;
 
     // Avoid allocations from the public getters.
     internal IReadOnlyList<string> ConfigFilePathsOrDefault
@@ -180,14 +180,14 @@ public sealed class SshConfigSettings
     /// <remarks>
     /// When unset, banners are ignored.
     /// </remarks>
-    public BannerHandler? BannerHandler
+    public BannerMessageHandler? BannerMessageHandler
     {
-        get => _bannerHandler;
+        get => _bannerMessageHandler;
         set
         {
             ThrowIfLocked();
 
-            _bannerHandler = value;
+            _bannerMessageHandler = value;
         }
     }
 

--- a/src/Tmds.Ssh/SshConfigSettings.cs
+++ b/src/Tmds.Ssh/SshConfigSettings.cs
@@ -38,7 +38,7 @@ public sealed class SshConfigSettings
     private TimeSpan _connectTimeout = SshClientSettings.DefaultConnectTimeout;
     private HostAuthentication? _hostAuthentication;
     private PasswordPrompt? _passwordPrompt;
-    private BannerMessageHandler? _bannerMessageHandler;
+    private BannerHandler? _bannerHandler;
 
     // Avoid allocations from the public getters.
     internal IReadOnlyList<string> ConfigFilePathsOrDefault
@@ -180,14 +180,14 @@ public sealed class SshConfigSettings
     /// <remarks>
     /// When unset, banners are ignored.
     /// </remarks>
-    public BannerMessageHandler? BannerMessageHandler
+    public BannerHandler? BannerHandler
     {
-        get => _bannerMessageHandler;
+        get => _bannerHandler;
         set
         {
             ThrowIfLocked();
 
-            _bannerMessageHandler = value;
+            _bannerHandler = value;
         }
     }
 

--- a/src/Tmds.Ssh/SshConfigSettings.cs
+++ b/src/Tmds.Ssh/SshConfigSettings.cs
@@ -38,6 +38,7 @@ public sealed class SshConfigSettings
     private TimeSpan _connectTimeout = SshClientSettings.DefaultConnectTimeout;
     private HostAuthentication? _hostAuthentication;
     private PasswordPrompt? _passwordPrompt;
+    private BannerHandler? _bannerHandler;
 
     // Avoid allocations from the public getters.
     internal IReadOnlyList<string> ConfigFilePathsOrDefault
@@ -170,6 +171,23 @@ public sealed class SshConfigSettings
             ThrowIfLocked();
 
             _passwordPrompt = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the handler for banners sent by the server during authentication.
+    /// </summary>
+    /// <remarks>
+    /// When unset, banners are ignored.
+    /// </remarks>
+    public BannerHandler? BannerHandler
+    {
+        get => _bannerHandler;
+        set
+        {
+            ThrowIfLocked();
+
+            _bannerHandler = value;
         }
     }
 

--- a/src/Tmds.Ssh/SshSession.Authentication.cs
+++ b/src/Tmds.Ssh/SshSession.Authentication.cs
@@ -42,7 +42,7 @@ sealed partial class SshSession
             connection, _settings.UserName,
             _settings.ClientKeyAlgorithmsOrDefault, SshClientSettings.SupportedClientKeyAlgorithms,
             keySignatureAlgorithms,
-            _settings.MinimumRSAKeySize, ConnectionInfo, _settings.BannerMessageHandler, Logger);
+            _settings.MinimumRSAKeySize, ConnectionInfo, _settings.BannerHandler, Logger);
 
         HashSet<Name>? rejectedMethods = null;
         HashSet<Name>? failedMethods = null;

--- a/src/Tmds.Ssh/SshSession.Authentication.cs
+++ b/src/Tmds.Ssh/SshSession.Authentication.cs
@@ -42,7 +42,7 @@ sealed partial class SshSession
             connection, _settings.UserName,
             _settings.ClientKeyAlgorithmsOrDefault, SshClientSettings.SupportedClientKeyAlgorithms,
             keySignatureAlgorithms,
-            _settings.MinimumRSAKeySize, ConnectionInfo, _settings.BannerHandler, Logger);
+            _settings.MinimumRSAKeySize, ConnectionInfo, _settings.BannerMessageHandler, Logger);
 
         HashSet<Name>? rejectedMethods = null;
         HashSet<Name>? failedMethods = null;

--- a/src/Tmds.Ssh/SshSession.Authentication.cs
+++ b/src/Tmds.Ssh/SshSession.Authentication.cs
@@ -42,7 +42,7 @@ sealed partial class SshSession
             connection, _settings.UserName,
             _settings.ClientKeyAlgorithmsOrDefault, SshClientSettings.SupportedClientKeyAlgorithms,
             keySignatureAlgorithms,
-            _settings.MinimumRSAKeySize, Logger);
+            _settings.MinimumRSAKeySize, ConnectionInfo, _settings.BannerHandler, Logger);
 
         HashSet<Name>? rejectedMethods = null;
         HashSet<Name>? failedMethods = null;

--- a/src/Tmds.Ssh/UserAuthContext.cs
+++ b/src/Tmds.Ssh/UserAuthContext.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.Logging;
 using System.Diagnostics;
+using System.Text;
 
 namespace Tmds.Ssh;
 
@@ -10,7 +11,7 @@ sealed class UserAuthContext
 {
     private readonly SshConnection _connection;
     private readonly SshConnectionInfo _connectionInfo;
-    private readonly BannerHandler? _bannerHandler;
+    private readonly BannerMessageHandler? _bannerMessageHandler;
     private readonly ILogger<SshClient> _logger;
     private readonly HashSet<SshKeyData> _publicKeysToSkip = new(); // track keys that were already attempted.
     private HashSet<Name>? _acceptedPublicKeyAlgorithms; // Allowed algorithms by config/server.
@@ -28,12 +29,12 @@ sealed class UserAuthContext
         IReadOnlyList<Name>? allowedSignatureAlgorithms,  // what the server accepts
         int minimumRSAKeySize,
         SshConnectionInfo connectionInfo,
-        BannerHandler? bannerHandler,
+        BannerMessageHandler? bannerMessageHandler,
         ILogger<SshClient> logger)
     {
         _connection = connection;
         _connectionInfo = connectionInfo;
-        _bannerHandler = bannerHandler;
+        _bannerMessageHandler = bannerMessageHandler;
         _logger = logger;
         UserName = userName;
         _supportedAcceptedPublicKeyAlgorithms = new HashSet<Name>(supportedPublicKeyAlgorithms);
@@ -110,8 +111,8 @@ sealed class UserAuthContext
                    time after this authentication protocol starts and before
                    authentication is successful. */
 
-                BannerHandler? bannerHandler = _bannerHandler;
-                BannerContext bannerContext = default;
+                BannerMessageHandler? bannerMessageHandler = _bannerMessageHandler;
+                BannerMessageContext bannerMessageContext = default;
                 try
                 {
                     // Check the limit before parsing or invoking user code. Preserve the existing
@@ -121,9 +122,9 @@ sealed class UserAuthContext
                         ThrowHelper.ThrowBannerTooLong();
                     }
 
-                    if (bannerHandler is not null)
+                    if (bannerMessageHandler is not null)
                     {
-                        bannerContext = ParseBanner(packet, _connectionInfo);
+                        bannerMessageContext = ParseBanner(packet, _connectionInfo);
                     }
                 }
                 finally
@@ -131,11 +132,9 @@ sealed class UserAuthContext
                     packet.Dispose();
                 }
 
-                if (bannerHandler is not null)
+                if (bannerMessageHandler is not null)
                 {
-                    // The handler completes before the next packet is read, so a server that sends
-                    // a banner and then waits for the user to act on it is handled in order.
-                    await bannerHandler(bannerContext, ct).ConfigureAwait(false);
+                    bannerMessageHandler(bannerMessageContext);
                 }
             }
             else
@@ -232,7 +231,7 @@ sealed class UserAuthContext
         _authResult = AuthResult.Failure;
     }
 
-    internal static BannerContext ParseBanner(ReadOnlyPacket packet, SshConnectionInfo connectionInfo)
+    internal static BannerMessageContext ParseBanner(ReadOnlyPacket packet, SshConnectionInfo connectionInfo)
     {
         var reader = packet.GetReader();
         /*
@@ -242,10 +241,50 @@ sealed class UserAuthContext
         */
         reader.ReadMessageId(MessageId.SSH_MSG_USERAUTH_BANNER);
         string message = reader.ReadUtf8String();
-        string languageTag = reader.ReadUtf8String();
+        reader.SkipString(); // language tag
         reader.ReadEnd();
 
-        return new BannerContext(message, languageTag, connectionInfo);
+        return new BannerMessageContext(EscapeControlCharacters(message), connectionInfo);
+    }
+
+    // Match OpenSSH: keep tab, carriage return, and newline; replace other control
+    // characters by an octal escape sequence per UTF-8 byte (RFC 4251 section 9.2).
+    internal static string EscapeControlCharacters(string message)
+    {
+        StringBuilder? builder = null;
+        int copiedUpTo = 0;
+        int index = 0;
+        Span<byte> utf8 = stackalloc byte[4];
+
+        foreach (Rune rune in message.EnumerateRunes())
+        {
+            if (Rune.IsControl(rune) && rune.Value is not ('\t' or '\n' or '\r'))
+            {
+                builder ??= new StringBuilder(message.Length + 16);
+                builder.Append(message, copiedUpTo, index - copiedUpTo);
+
+                int byteCount = rune.EncodeToUtf8(utf8);
+                for (int i = 0; i < byteCount; i++)
+                {
+                    byte b = utf8[i];
+                    builder.Append('\\')
+                           .Append((char)('0' + ((b >> 6) & 7)))
+                           .Append((char)('0' + ((b >> 3) & 7)))
+                           .Append((char)('0' + (b & 7)));
+                }
+
+                copiedUpTo = index + rune.Utf16SequenceLength;
+            }
+            index += rune.Utf16SequenceLength;
+        }
+
+        if (builder is null)
+        {
+            return message;
+        }
+
+        builder.Append(message, copiedUpTo, message.Length - copiedUpTo);
+        return builder.ToString();
     }
 
     private void ParseAuthFail(ReadOnlyPacket packet)

--- a/src/Tmds.Ssh/UserAuthContext.cs
+++ b/src/Tmds.Ssh/UserAuthContext.cs
@@ -2,6 +2,7 @@
 // See file LICENSE for full license details.
 
 using Microsoft.Extensions.Logging;
+using System.Buffers;
 using System.Diagnostics;
 using System.Text;
 
@@ -11,7 +12,7 @@ sealed class UserAuthContext
 {
     private readonly SshConnection _connection;
     private readonly SshConnectionInfo _connectionInfo;
-    private readonly BannerMessageHandler? _bannerMessageHandler;
+    private readonly BannerHandler? _bannerHandler;
     private readonly ILogger<SshClient> _logger;
     private readonly HashSet<SshKeyData> _publicKeysToSkip = new(); // track keys that were already attempted.
     private HashSet<Name>? _acceptedPublicKeyAlgorithms; // Allowed algorithms by config/server.
@@ -29,12 +30,12 @@ sealed class UserAuthContext
         IReadOnlyList<Name>? allowedSignatureAlgorithms,  // what the server accepts
         int minimumRSAKeySize,
         SshConnectionInfo connectionInfo,
-        BannerMessageHandler? bannerMessageHandler,
+        BannerHandler? bannerHandler,
         ILogger<SshClient> logger)
     {
         _connection = connection;
         _connectionInfo = connectionInfo;
-        _bannerMessageHandler = bannerMessageHandler;
+        _bannerHandler = bannerHandler;
         _logger = logger;
         UserName = userName;
         _supportedAcceptedPublicKeyAlgorithms = new HashSet<Name>(supportedPublicKeyAlgorithms);
@@ -111,7 +112,7 @@ sealed class UserAuthContext
                    time after this authentication protocol starts and before
                    authentication is successful. */
 
-                BannerMessageHandler? bannerMessageHandler = _bannerMessageHandler;
+                BannerHandler? bannerHandler = _bannerHandler;
                 BannerMessageContext bannerMessageContext = default;
                 try
                 {
@@ -122,7 +123,7 @@ sealed class UserAuthContext
                         ThrowHelper.ThrowBannerTooLong();
                     }
 
-                    if (bannerMessageHandler is not null)
+                    if (bannerHandler is not null)
                     {
                         bannerMessageContext = ParseBanner(packet, _connectionInfo);
                     }
@@ -132,9 +133,9 @@ sealed class UserAuthContext
                     packet.Dispose();
                 }
 
-                if (bannerMessageHandler is not null)
+                if (bannerHandler is not null)
                 {
-                    bannerMessageHandler(bannerMessageContext);
+                    bannerHandler(bannerMessageContext);
                 }
             }
             else
@@ -247,44 +248,88 @@ sealed class UserAuthContext
         return new BannerMessageContext(EscapeControlCharacters(message), connectionInfo);
     }
 
-    // Match OpenSSH: keep tab, carriage return, and newline; replace other control
-    // characters by an octal escape sequence per UTF-8 byte (RFC 4251 section 9.2).
-    internal static string EscapeControlCharacters(string message)
+    // Built from ShouldEscape so the vectorized scan can never drift from the scalar predicate.
+    private static readonly SearchValues<char> BannerCharsToEscape = CreateBannerCharsToEscape();
+
+    private static SearchValues<char> CreateBannerCharsToEscape()
     {
-        StringBuilder? builder = null;
-        int copiedUpTo = 0;
-        int index = 0;
-        Span<byte> utf8 = stackalloc byte[4];
-
-        foreach (Rune rune in message.EnumerateRunes())
+        // ShouldEscape only returns true for characters in the C0/DEL/C1 range (<= U+009F),
+        // so there is no need to scan the rest of the BMP when building the set.
+        Span<char> chars = stackalloc char[0xA0];
+        int count = 0;
+        for (char c = '\0'; c <= '\u009F'; c++)
         {
-            if (Rune.IsControl(rune) && rune.Value is not ('\t' or '\n' or '\r'))
+            if (ShouldEscape(c))
             {
-                builder ??= new StringBuilder(message.Length + 16);
-                builder.Append(message, copiedUpTo, index - copiedUpTo);
-
-                int byteCount = rune.EncodeToUtf8(utf8);
-                for (int i = 0; i < byteCount; i++)
-                {
-                    byte b = utf8[i];
-                    builder.Append('\\')
-                           .Append((char)('0' + ((b >> 6) & 7)))
-                           .Append((char)('0' + ((b >> 3) & 7)))
-                           .Append((char)('0' + (b & 7)));
-                }
-
-                copiedUpTo = index + rune.Utf16SequenceLength;
+                chars[count++] = c;
             }
-            index += rune.Utf16SequenceLength;
         }
 
-        if (builder is null)
+        return SearchValues.Create(chars.Slice(0, count));
+    }
+
+    private static bool ShouldEscape(char c)
+    {
+        // Escape the control characters that can drive terminal escape sequences when the banner
+        // is written to a console: the C0 range (U+0000-U+001F), DEL (U+007F) and the C1 range
+        // (U+0080-U+009F). Tab, newline and carriage return are preserved.
+        if (c is '\t' or '\n' or '\r')
+        {
+            return false;
+        }
+
+        return c <= '\u001F' || (c >= '\u007F' && c <= '\u009F');
+    }
+
+    // Escapes like Microsoft.Extensions.Logging.Console ConsoleControlCharacterSanitizer.
+    internal static string EscapeControlCharacters(string message)
+    {
+        ReadOnlySpan<char> remaining = message;
+        int firstEscapedCharacterIndex = remaining.IndexOfAny(BannerCharsToEscape);
+        if (firstEscapedCharacterIndex < 0)
         {
             return message;
         }
 
-        builder.Append(message, copiedUpTo, message.Length - copiedUpTo);
-        return builder.ToString();
+        var escaped = new ValueStringBuilder(stackalloc char[256]);
+        escaped.Append(remaining.Slice(0, firstEscapedCharacterIndex));
+        remaining = remaining.Slice(firstEscapedCharacterIndex);
+
+        while (true)
+        {
+            // remaining[0] is always a character that must be escaped.
+            AppendEscaped(ref escaped, remaining[0]);
+            remaining = remaining.Slice(1);
+
+            int next = remaining.IndexOfAny(BannerCharsToEscape);
+            if (next < 0)
+            {
+                escaped.Append(remaining);
+                break;
+            }
+
+            escaped.Append(remaining.Slice(0, next));
+            remaining = remaining.Slice(next);
+        }
+
+        return escaped.ToString();
+    }
+
+    private static void AppendEscaped(ref ValueStringBuilder builder, char c)
+    {
+        Span<char> escaped = builder.AppendSpan(6);
+        escaped[0] = '\\';
+        escaped[1] = 'u';
+        escaped[2] = ToHexChar(c >> 12);
+        escaped[3] = ToHexChar(c >> 8);
+        escaped[4] = ToHexChar(c >> 4);
+        escaped[5] = ToHexChar(c);
+    }
+
+    private static char ToHexChar(int nibble)
+    {
+        nibble &= 0xF;
+        return (char)(nibble < 10 ? '0' + nibble : 'A' + nibble - 10);
     }
 
     private void ParseAuthFail(ReadOnlyPacket packet)

--- a/src/Tmds.Ssh/UserAuthContext.cs
+++ b/src/Tmds.Ssh/UserAuthContext.cs
@@ -9,6 +9,8 @@ namespace Tmds.Ssh;
 sealed class UserAuthContext
 {
     private readonly SshConnection _connection;
+    private readonly SshConnectionInfo _connectionInfo;
+    private readonly BannerHandler? _bannerHandler;
     private readonly ILogger<SshClient> _logger;
     private readonly HashSet<SshKeyData> _publicKeysToSkip = new(); // track keys that were already attempted.
     private HashSet<Name>? _acceptedPublicKeyAlgorithms; // Allowed algorithms by config/server.
@@ -25,9 +27,13 @@ sealed class UserAuthContext
         IReadOnlyList<Name> supportedPublicKeyAlgorithms, // what the library supports
         IReadOnlyList<Name>? allowedSignatureAlgorithms,  // what the server accepts
         int minimumRSAKeySize,
+        SshConnectionInfo connectionInfo,
+        BannerHandler? bannerHandler,
         ILogger<SshClient> logger)
     {
         _connection = connection;
+        _connectionInfo = connectionInfo;
+        _bannerHandler = bannerHandler;
         _logger = logger;
         UserName = userName;
         _supportedAcceptedPublicKeyAlgorithms = new HashSet<Name>(supportedPublicKeyAlgorithms);
@@ -104,9 +110,19 @@ sealed class UserAuthContext
                    time after this authentication protocol starts and before
                    authentication is successful. */
 
-                // TODO: provide the banner to the user.
+                if (_bannerHandler is { } bannerHandler)
+                {
+                    BannerContext bannerContext = ParseBanner(packet, _connectionInfo);
+                    packet.Dispose();
 
-                packet.Dispose();
+                    // The handler completes before the next packet is read, so a server that sends
+                    // a banner and then waits for the user to act on it is handled in order.
+                    await bannerHandler(bannerContext, ct).ConfigureAwait(false);
+                }
+                else
+                {
+                    packet.Dispose();
+                }
 
                 if (_bannerPacketCount++ > Constants.MaxBannerPackets)
                 {
@@ -205,6 +221,21 @@ sealed class UserAuthContext
     {
         _currentMethod = default;
         _authResult = AuthResult.Failure;
+    }
+
+    internal static BannerContext ParseBanner(ReadOnlyPacket packet, SshConnectionInfo connectionInfo)
+    {
+        var reader = packet.GetReader();
+        /*
+            byte         SSH_MSG_USERAUTH_BANNER
+            string       message in ISO-10646 UTF-8 encoding [RFC3629]
+            string       language tag [RFC3066]
+        */
+        reader.ReadMessageId(MessageId.SSH_MSG_USERAUTH_BANNER);
+        string message = reader.ReadUtf8String();
+        string languageTag = reader.ReadUtf8String();
+
+        return new BannerContext(message, languageTag, connectionInfo);
     }
 
     private void ParseAuthFail(ReadOnlyPacket packet)

--- a/src/Tmds.Ssh/UserAuthContext.cs
+++ b/src/Tmds.Ssh/UserAuthContext.cs
@@ -110,23 +110,32 @@ sealed class UserAuthContext
                    time after this authentication protocol starts and before
                    authentication is successful. */
 
-                if (_bannerHandler is { } bannerHandler)
+                BannerHandler? bannerHandler = _bannerHandler;
+                BannerContext bannerContext = default;
+                try
                 {
-                    BannerContext bannerContext = ParseBanner(packet, _connectionInfo);
-                    packet.Dispose();
+                    // Check the limit before parsing or invoking user code. Preserve the existing
+                    // counting semantics while ensuring an over-limit packet is not observed.
+                    if (_bannerPacketCount++ > Constants.MaxBannerPackets)
+                    {
+                        ThrowHelper.ThrowBannerTooLong();
+                    }
 
+                    if (bannerHandler is not null)
+                    {
+                        bannerContext = ParseBanner(packet, _connectionInfo);
+                    }
+                }
+                finally
+                {
+                    packet.Dispose();
+                }
+
+                if (bannerHandler is not null)
+                {
                     // The handler completes before the next packet is read, so a server that sends
                     // a banner and then waits for the user to act on it is handled in order.
                     await bannerHandler(bannerContext, ct).ConfigureAwait(false);
-                }
-                else
-                {
-                    packet.Dispose();
-                }
-
-                if (_bannerPacketCount++ > Constants.MaxBannerPackets)
-                {
-                    ThrowHelper.ThrowBannerTooLong();
                 }
             }
             else
@@ -234,6 +243,7 @@ sealed class UserAuthContext
         reader.ReadMessageId(MessageId.SSH_MSG_USERAUTH_BANNER);
         string message = reader.ReadUtf8String();
         string languageTag = reader.ReadUtf8String();
+        reader.ReadEnd();
 
         return new BannerContext(message, languageTag, connectionInfo);
     }

--- a/src/docfx/index.md
+++ b/src/docfx/index.md
@@ -304,6 +304,18 @@ Credentials = [ new KerberosCredential() ]
 Credentials = [ new KerberosCredential(new NetworkCredential("user", "password", "REALM"), delegateCredential: true) ]
 ```
 
+#### Authentication Banners
+
+An SSH server may send banner messages while authenticating. Set <xref:Tmds.Ssh.SshClientSettings.BannerMessageHandler> to handle each message. The handler is also available as <xref:Tmds.Ssh.SshConfigSettings.BannerMessageHandler>. When it is unset, banners are ignored. Control characters other than tab, carriage return, and newline are replaced by escape sequences so the message is safe to write to a terminal:
+
+```csharp
+var settings = new SshClientSettings("user@example.com")
+{
+    BannerMessageHandler = (BannerMessageContext context) =>
+        Console.Error.Write(context.Message),
+};
+```
+
 ### Server Authentication
 
 By default, the server's host key is verified against the OpenSSH `known_hosts` files. The <xref:Tmds.Ssh.SshClientSettings.UserKnownHostsFilePaths> and <xref:Tmds.Ssh.SshClientSettings.GlobalKnownHostsFilePaths> properties control which files are used.

--- a/src/docfx/index.md
+++ b/src/docfx/index.md
@@ -304,18 +304,6 @@ Credentials = [ new KerberosCredential() ]
 Credentials = [ new KerberosCredential(new NetworkCredential("user", "password", "REALM"), delegateCredential: true) ]
 ```
 
-#### Authentication Banners
-
-An SSH server may send banner messages while authenticating. Set <xref:Tmds.Ssh.SshClientSettings.BannerMessageHandler> to handle each message. The handler is also available as <xref:Tmds.Ssh.SshConfigSettings.BannerMessageHandler>. When it is unset, banners are ignored. Control characters other than tab, carriage return, and newline are replaced by escape sequences so the message is safe to write to a terminal:
-
-```csharp
-var settings = new SshClientSettings("user@example.com")
-{
-    BannerMessageHandler = (BannerMessageContext context) =>
-        Console.Error.Write(context.Message),
-};
-```
-
 ### Server Authentication
 
 By default, the server's host key is verified against the OpenSSH `known_hosts` files. The <xref:Tmds.Ssh.SshClientSettings.UserKnownHostsFilePaths> and <xref:Tmds.Ssh.SshClientSettings.GlobalKnownHostsFilePaths> properties control which files are used.
@@ -345,16 +333,17 @@ When using <xref:Tmds.Ssh.SshConfigSettings>, the <xref:Tmds.Ssh.SshConfigSettin
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `ConnectTimeout` | 15 seconds | Maximum duration for establishing an authenticated connection. |
 | `AutoConnect` | `true` | Automatically connect on first operation. |
 | `AutoReconnect` | `false` | Reconnect automatically after an unexpected disconnect on the next operation. |
-| `TcpKeepAlive` | `true` | Enable TCP keep-alive. |
-| `KeepAliveInterval` | `TimeSpan.Zero` | Interval between SSH keep-alive messages. |
-| `KeepAliveCountMax` | 3 | Max keep-alive messages before disconnecting. |
+| `BannerHandler` | | Called for each banner message the server sends during authentication; control characters are escaped. When unset, banners are ignored. |
 | `BatchMode` | `false` | Disable interactive prompts. |
+| `ConnectTimeout` | 15 seconds | Maximum duration for establishing an authenticated connection. |
 | `EnableBatchModeWhenConsoleIsRedirected` | `true` | Automatically enable batch mode when the console is redirected. |
-| `MinimumRSAKeySize` | 2048 | Minimum RSA key size accepted. |
 | `EnvironmentVariables` | | Environment variables set for all remote processes. |
+| `KeepAliveCountMax` | 3 | Max keep-alive messages before disconnecting. |
+| `KeepAliveInterval` | `TimeSpan.Zero` | Interval between SSH keep-alive messages. |
+| `MinimumRSAKeySize` | 2048 | Minimum RSA key size accepted. |
+| `TcpKeepAlive` | `true` | Enable TCP keep-alive. |
 
 ### Jump hosts
 

--- a/src/ssh-cp/Program.cs
+++ b/src/ssh-cp/Program.cs
@@ -381,6 +381,9 @@ static SshConfigSettings CreateSshConfigSettings(string[] options)
     }
     configSettings.Options = optionsDict;
 
+    configSettings.BannerMessageHandler = (BannerMessageContext ctx) =>
+        Console.Error.Write(ctx.Message);
+
     configSettings.PasswordPrompt = (PasswordPromptContext ctx, CancellationToken ct) =>
     {
         if (ctx.IsBatchMode)

--- a/src/ssh-cp/Program.cs
+++ b/src/ssh-cp/Program.cs
@@ -381,7 +381,7 @@ static SshConfigSettings CreateSshConfigSettings(string[] options)
     }
     configSettings.Options = optionsDict;
 
-    configSettings.BannerMessageHandler = (BannerMessageContext ctx) =>
+    configSettings.BannerHandler = (BannerMessageContext ctx) =>
         Console.Error.Write(ctx.Message);
 
     configSettings.PasswordPrompt = (PasswordPromptContext ctx, CancellationToken ct) =>

--- a/src/ssh/Program.cs
+++ b/src/ssh/Program.cs
@@ -270,7 +270,7 @@ static SshConfigSettings CreateSshConfigSettings(string[] options)
     }
     configSettings.Options = optionsDict;
 
-    configSettings.BannerMessageHandler = (BannerMessageContext ctx) =>
+    configSettings.BannerHandler = (BannerMessageContext ctx) =>
         Console.Error.Write(ctx.Message);
 
     configSettings.PasswordPrompt = (PasswordPromptContext ctx, CancellationToken ct) =>

--- a/src/ssh/Program.cs
+++ b/src/ssh/Program.cs
@@ -270,6 +270,9 @@ static SshConfigSettings CreateSshConfigSettings(string[] options)
     }
     configSettings.Options = optionsDict;
 
+    configSettings.BannerMessageHandler = (BannerMessageContext ctx) =>
+        Console.Error.Write(ctx.Message);
+
     configSettings.PasswordPrompt = (PasswordPromptContext ctx, CancellationToken ct) =>
     {
         if (ctx.IsBatchMode)

--- a/test/Tmds.Ssh.Tests/BannerTests.cs
+++ b/test/Tmds.Ssh.Tests/BannerTests.cs
@@ -40,6 +40,34 @@ public class BannerServerTests
 
         await client.ConnectAsync();
     }
+
+    [Fact]
+    public async Task Connect_WaitsForBannerHandler()
+    {
+        var handlerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completeHandler = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var settings = _sshServer.CreateSshClientSettings(s =>
+            s.BannerHandler = async (context, ct) =>
+            {
+                handlerStarted.SetResult();
+                await completeHandler.Task.WaitAsync(ct);
+            });
+
+        using var client = new SshClient(settings);
+        Task connectTask = client.ConnectAsync();
+
+        try
+        {
+            await handlerStarted.Task.TimeoutAfter(TimeSpan.FromSeconds(5));
+            Assert.False(connectTask.IsCompleted);
+        }
+        finally
+        {
+            completeHandler.TrySetResult();
+        }
+
+        await connectTask;
+    }
 }
 
 public class BannerTests
@@ -77,13 +105,29 @@ public class BannerTests
         Assert.Equal(message, context.Message);
     }
 
-    private static Packet CreateBannerPacket(string message, string languageTag)
+    [Fact]
+    public void ParseBanner_RejectsTrailingData()
+    {
+        using Packet packet = CreateBannerPacket("Welcome.", "", addTrailingByte: true);
+
+        Assert.Throws<InvalidDataException>(
+            () => UserAuthContext.ParseBanner(packet, new SshConnectionInfo()));
+    }
+
+    private static Packet CreateBannerPacket(
+        string message,
+        string languageTag,
+        bool addTrailingByte = false)
     {
         using var packet = new SequencePool().RentPacket();
         var writer = packet.GetWriter();
         writer.WriteMessageId(MessageId.SSH_MSG_USERAUTH_BANNER);
         writer.WriteString(message);
         writer.WriteString(languageTag);
+        if (addTrailingByte)
+        {
+            writer.WriteByte(0);
+        }
         return packet.Move();
     }
 }

--- a/test/Tmds.Ssh.Tests/BannerTests.cs
+++ b/test/Tmds.Ssh.Tests/BannerTests.cs
@@ -13,12 +13,12 @@ public class BannerServerTests
     }
 
     [Fact]
-    public async Task BannerMessageHandler_ReceivesTheServerBanner()
+    public async Task BannerHandler_ReceivesTheServerBanner()
     {
         List<string> banners = new();
 
         var settings = _sshServer.CreateSshClientSettings(s =>
-            s.BannerMessageHandler = context => banners.Add(context.Message));
+            s.BannerHandler = context => banners.Add(context.Message));
 
         using var client = new SshClient(settings);
         await client.ConnectAsync();
@@ -74,12 +74,12 @@ public class BannerTests
     [Theory]
     [InlineData("", "")]
     [InlineData("line one\r\n\tline two", "line one\r\n\tline two")]
-    [InlineData("\0", "\\000")]
-    [InlineData("\a", "\\007")]
-    [InlineData("\u001b[2J", "\\033[2J")]
-    [InlineData("\u007f", "\\177")]
-    [InlineData("\u0085", "\\302\\205")]
-    public void EscapeControlCharacters_UsesOpenSshSemantics(string message, string expected)
+    [InlineData("\0", "\\u0000")]
+    [InlineData("\a", "\\u0007")]
+    [InlineData("\u001b[2J", "\\u001B[2J")]
+    [InlineData("\u007f", "\\u007F")]
+    [InlineData("\u0085", "\\u0085")]
+    public void EscapeControlCharacters_EscapesAsUnicodeHex(string message, string expected)
     {
         Assert.Equal(expected, UserAuthContext.EscapeControlCharacters(message));
     }

--- a/test/Tmds.Ssh.Tests/BannerTests.cs
+++ b/test/Tmds.Ssh.Tests/BannerTests.cs
@@ -2,27 +2,23 @@ using Xunit;
 
 namespace Tmds.Ssh.Tests;
 
-[Collection(nameof(BannerSshServerCollection))]
+[Collection(nameof(SshServerCollection))]
 public class BannerServerTests
 {
-    private readonly BannerSshServer _sshServer;
+    private readonly SshServer _sshServer;
 
-    public BannerServerTests(BannerSshServer sshServer)
+    public BannerServerTests(SshServer sshServer)
     {
         _sshServer = sshServer;
     }
 
     [Fact]
-    public async Task BannerHandler_ReceivesTheServerBanner()
+    public async Task BannerMessageHandler_ReceivesTheServerBanner()
     {
         List<string> banners = new();
 
         var settings = _sshServer.CreateSshClientSettings(s =>
-            s.BannerHandler = (context, ct) =>
-            {
-                banners.Add(context.Message);
-                return default;
-            });
+            s.BannerMessageHandler = context => banners.Add(context.Message));
 
         using var client = new SshClient(settings);
         await client.ConnectAsync();
@@ -30,43 +26,6 @@ public class BannerServerTests
         string banner = Assert.Single(banners);
         Assert.Contains("Authorized use only.", banner);
         Assert.Contains("Second line of the banner.", banner);
-    }
-
-    [Fact]
-    public async Task Connect_SucceedsWithoutABannerHandler()
-    {
-        // Banners are ignored when no handler is set; this is the pre-existing behaviour.
-        using var client = new SshClient(_sshServer.CreateSshClientSettings());
-
-        await client.ConnectAsync();
-    }
-
-    [Fact]
-    public async Task Connect_WaitsForBannerHandler()
-    {
-        var handlerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var completeHandler = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var settings = _sshServer.CreateSshClientSettings(s =>
-            s.BannerHandler = async (context, ct) =>
-            {
-                handlerStarted.SetResult();
-                await completeHandler.Task.WaitAsync(ct);
-            });
-
-        using var client = new SshClient(settings);
-        Task connectTask = client.ConnectAsync();
-
-        try
-        {
-            await handlerStarted.Task.TimeoutAfter(TimeSpan.FromSeconds(5));
-            Assert.False(connectTask.IsCompleted);
-        }
-        finally
-        {
-            completeHandler.TrySetResult();
-        }
-
-        await connectTask;
     }
 }
 
@@ -78,29 +37,27 @@ public class BannerTests
     [InlineData("Welcome.", "en-US")]
     [InlineData("line one\r\nline two\r\n", "")]
     [InlineData("ünïcödé ✔", "nl-BE")]
-    public void ParseBanner_ReadsMessageAndLanguageTag(string message, string languageTag)
+    public void ParseBanner_ReadsMessage(string message, string languageTag)
     {
         using Packet packet = CreateBannerPacket(message, languageTag);
         var connectionInfo = new SshConnectionInfo() { HostName = "host", UserName = "user", Port = 22 };
 
-        BannerContext context = UserAuthContext.ParseBanner(packet, connectionInfo);
+        BannerMessageContext context = UserAuthContext.ParseBanner(packet, connectionInfo);
 
         Assert.Equal(message, context.Message);
-        Assert.Equal(languageTag, context.LanguageTag);
         Assert.Same(connectionInfo, context.ConnectionInfo);
     }
 
     [Fact]
-    public void ParseBanner_KeepsTheMessageVerbatim()
+    public void ParseBanner_KeepsPrintableMessageVerbatim()
     {
-        // The message is server-controlled and may carry anything, including the URL that
-        // Tailscale SSH check mode sends before it will finish authenticating. Callers decide how
-        // to render it; parsing must not alter it.
+        // Printable text, including the URL that Tailscale SSH check mode sends before it will
+        // finish authenticating, is not changed by control character escaping.
         const string message = "# Tailscale SSH requires an additional check.\n"
             + "# To authenticate, visit: https://login.tailscale.com/a/0123456789ab\n";
 
         using Packet packet = CreateBannerPacket(message, languageTag: "");
-        BannerContext context = UserAuthContext.ParseBanner(packet, new SshConnectionInfo());
+        BannerMessageContext context = UserAuthContext.ParseBanner(packet, new SshConnectionInfo());
 
         Assert.Equal(message, context.Message);
     }
@@ -112,6 +69,19 @@ public class BannerTests
 
         Assert.Throws<InvalidDataException>(
             () => UserAuthContext.ParseBanner(packet, new SshConnectionInfo()));
+    }
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("line one\r\n\tline two", "line one\r\n\tline two")]
+    [InlineData("\0", "\\000")]
+    [InlineData("\a", "\\007")]
+    [InlineData("\u001b[2J", "\\033[2J")]
+    [InlineData("\u007f", "\\177")]
+    [InlineData("\u0085", "\\302\\205")]
+    public void EscapeControlCharacters_UsesOpenSshSemantics(string message, string expected)
+    {
+        Assert.Equal(expected, UserAuthContext.EscapeControlCharacters(message));
     }
 
     private static Packet CreateBannerPacket(

--- a/test/Tmds.Ssh.Tests/BannerTests.cs
+++ b/test/Tmds.Ssh.Tests/BannerTests.cs
@@ -1,0 +1,89 @@
+using Xunit;
+
+namespace Tmds.Ssh.Tests;
+
+[Collection(nameof(BannerSshServerCollection))]
+public class BannerServerTests
+{
+    private readonly BannerSshServer _sshServer;
+
+    public BannerServerTests(BannerSshServer sshServer)
+    {
+        _sshServer = sshServer;
+    }
+
+    [Fact]
+    public async Task BannerHandler_ReceivesTheServerBanner()
+    {
+        List<string> banners = new();
+
+        var settings = _sshServer.CreateSshClientSettings(s =>
+            s.BannerHandler = (context, ct) =>
+            {
+                banners.Add(context.Message);
+                return default;
+            });
+
+        using var client = new SshClient(settings);
+        await client.ConnectAsync();
+
+        string banner = Assert.Single(banners);
+        Assert.Contains("Authorized use only.", banner);
+        Assert.Contains("Second line of the banner.", banner);
+    }
+
+    [Fact]
+    public async Task Connect_SucceedsWithoutABannerHandler()
+    {
+        // Banners are ignored when no handler is set; this is the pre-existing behaviour.
+        using var client = new SshClient(_sshServer.CreateSshClientSettings());
+
+        await client.ConnectAsync();
+    }
+}
+
+public class BannerTests
+{
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("Welcome.", "")]
+    [InlineData("Welcome.", "en-US")]
+    [InlineData("line one\r\nline two\r\n", "")]
+    [InlineData("ünïcödé ✔", "nl-BE")]
+    public void ParseBanner_ReadsMessageAndLanguageTag(string message, string languageTag)
+    {
+        using Packet packet = CreateBannerPacket(message, languageTag);
+        var connectionInfo = new SshConnectionInfo() { HostName = "host", UserName = "user", Port = 22 };
+
+        BannerContext context = UserAuthContext.ParseBanner(packet, connectionInfo);
+
+        Assert.Equal(message, context.Message);
+        Assert.Equal(languageTag, context.LanguageTag);
+        Assert.Same(connectionInfo, context.ConnectionInfo);
+    }
+
+    [Fact]
+    public void ParseBanner_KeepsTheMessageVerbatim()
+    {
+        // The message is server-controlled and may carry anything, including the URL that
+        // Tailscale SSH check mode sends before it will finish authenticating. Callers decide how
+        // to render it; parsing must not alter it.
+        const string message = "# Tailscale SSH requires an additional check.\n"
+            + "# To authenticate, visit: https://login.tailscale.com/a/0123456789ab\n";
+
+        using Packet packet = CreateBannerPacket(message, languageTag: "");
+        BannerContext context = UserAuthContext.ParseBanner(packet, new SshConnectionInfo());
+
+        Assert.Equal(message, context.Message);
+    }
+
+    private static Packet CreateBannerPacket(string message, string languageTag)
+    {
+        using var packet = new SequencePool().RentPacket();
+        var writer = packet.GetWriter();
+        writer.WriteMessageId(MessageId.SSH_MSG_USERAUTH_BANNER);
+        writer.WriteString(message);
+        writer.WriteString(languageTag);
+        return packet.Move();
+    }
+}

--- a/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
+++ b/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
@@ -20,14 +20,12 @@ namespace Tmds.Ssh
         public bool Remove(string item) { }
         public void RemoveAt(int index) { }
     }
-    public struct BannerContext
+    public struct BannerMessageContext
     {
         public Tmds.Ssh.SshConnectionInfo ConnectionInfo { get; }
-        public bool IsBatchMode { get; }
-        public string LanguageTag { get; }
         public string Message { get; }
     }
-    public delegate System.Threading.Tasks.ValueTask BannerHandler(Tmds.Ssh.BannerContext context, System.Threading.CancellationToken cancellationToken);
+    public delegate void BannerMessageHandler(Tmds.Ssh.BannerMessageContext context);
     public sealed class CertificateCredential : Tmds.Ssh.Credential
     {
         public CertificateCredential(string path, Tmds.Ssh.PrivateKeyCredential privateKey) { }
@@ -557,7 +555,7 @@ namespace Tmds.Ssh
         public SshClientSettings(string destination) { }
         public bool AutoConnect { get; set; }
         public bool AutoReconnect { get; set; }
-        public Tmds.Ssh.BannerHandler? BannerHandler { get; set; }
+        public Tmds.Ssh.BannerMessageHandler? BannerMessageHandler { get; set; }
         public bool BatchMode { get; set; }
         public Tmds.Ssh.AlgorithmList? ClientKeyAlgorithms { get; set; }
         public System.TimeSpan ConnectTimeout { get; set; }
@@ -641,7 +639,7 @@ namespace Tmds.Ssh
         public SshConfigSettings() { }
         public bool AutoConnect { get; set; }
         public bool AutoReconnect { get; set; }
-        public Tmds.Ssh.BannerHandler? BannerHandler { get; set; }
+        public Tmds.Ssh.BannerMessageHandler? BannerMessageHandler { get; set; }
         public System.Collections.Generic.List<string> ConfigFilePaths { get; set; }
         public System.TimeSpan ConnectTimeout { get; set; }
         public Tmds.Ssh.HostAuthentication? HostAuthentication { get; set; }

--- a/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
+++ b/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
@@ -20,6 +20,14 @@ namespace Tmds.Ssh
         public bool Remove(string item) { }
         public void RemoveAt(int index) { }
     }
+    public struct BannerContext
+    {
+        public Tmds.Ssh.SshConnectionInfo ConnectionInfo { get; }
+        public bool IsBatchMode { get; }
+        public string LanguageTag { get; }
+        public string Message { get; }
+    }
+    public delegate System.Threading.Tasks.ValueTask BannerHandler(Tmds.Ssh.BannerContext context, System.Threading.CancellationToken cancellationToken);
     public sealed class CertificateCredential : Tmds.Ssh.Credential
     {
         public CertificateCredential(string path, Tmds.Ssh.PrivateKeyCredential privateKey) { }
@@ -549,6 +557,7 @@ namespace Tmds.Ssh
         public SshClientSettings(string destination) { }
         public bool AutoConnect { get; set; }
         public bool AutoReconnect { get; set; }
+        public Tmds.Ssh.BannerHandler? BannerHandler { get; set; }
         public bool BatchMode { get; set; }
         public Tmds.Ssh.AlgorithmList? ClientKeyAlgorithms { get; set; }
         public System.TimeSpan ConnectTimeout { get; set; }
@@ -632,6 +641,7 @@ namespace Tmds.Ssh
         public SshConfigSettings() { }
         public bool AutoConnect { get; set; }
         public bool AutoReconnect { get; set; }
+        public Tmds.Ssh.BannerHandler? BannerHandler { get; set; }
         public System.Collections.Generic.List<string> ConfigFilePaths { get; set; }
         public System.TimeSpan ConnectTimeout { get; set; }
         public Tmds.Ssh.HostAuthentication? HostAuthentication { get; set; }

--- a/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
+++ b/test/Tmds.Ssh.Tests/PublicApiTest.PublicApi.DotNet.verified.txt
@@ -20,12 +20,12 @@ namespace Tmds.Ssh
         public bool Remove(string item) { }
         public void RemoveAt(int index) { }
     }
+    public delegate void BannerHandler(Tmds.Ssh.BannerMessageContext context);
     public struct BannerMessageContext
     {
         public Tmds.Ssh.SshConnectionInfo ConnectionInfo { get; }
         public string Message { get; }
     }
-    public delegate void BannerMessageHandler(Tmds.Ssh.BannerMessageContext context);
     public sealed class CertificateCredential : Tmds.Ssh.Credential
     {
         public CertificateCredential(string path, Tmds.Ssh.PrivateKeyCredential privateKey) { }
@@ -555,7 +555,7 @@ namespace Tmds.Ssh
         public SshClientSettings(string destination) { }
         public bool AutoConnect { get; set; }
         public bool AutoReconnect { get; set; }
-        public Tmds.Ssh.BannerMessageHandler? BannerMessageHandler { get; set; }
+        public Tmds.Ssh.BannerHandler? BannerHandler { get; set; }
         public bool BatchMode { get; set; }
         public Tmds.Ssh.AlgorithmList? ClientKeyAlgorithms { get; set; }
         public System.TimeSpan ConnectTimeout { get; set; }
@@ -639,7 +639,7 @@ namespace Tmds.Ssh
         public SshConfigSettings() { }
         public bool AutoConnect { get; set; }
         public bool AutoReconnect { get; set; }
-        public Tmds.Ssh.BannerMessageHandler? BannerMessageHandler { get; set; }
+        public Tmds.Ssh.BannerHandler? BannerHandler { get; set; }
         public System.Collections.Generic.List<string> ConfigFilePaths { get; set; }
         public System.TimeSpan ConnectTimeout { get; set; }
         public Tmds.Ssh.HostAuthentication? HostAuthentication { get; set; }

--- a/test/Tmds.Ssh.Tests/SshServer.cs
+++ b/test/Tmds.Ssh.Tests/SshServer.cs
@@ -86,6 +86,7 @@ public class SshServer : IDisposable
     private readonly string _krbConfigFilePath;
     private readonly string _sshConfigFilePath;
     private readonly string? _sshdConfigFilePath;
+    private readonly List<string> _extraFilePaths = new();
     private readonly IMessageSink _messageSink;
     private bool _useDockerInstead;
 
@@ -98,7 +99,10 @@ public class SshServer : IDisposable
         _messageSink.OnMessage(new Xunit.v3.DiagnosticMessage(message));
     }
 
-    protected SshServer(string? sshdConfig, IMessageSink messageSink, string userPassword = "secret")
+    /// <param name="extraFiles">Files to mount in the container, keyed by their path in the container.
+    /// Needed for sshd options that take a file path, like 'Banner'.</param>
+    protected SshServer(string? sshdConfig, IMessageSink messageSink, string userPassword = "secret",
+        IReadOnlyDictionary<string, string>? extraFiles = null)
     {
         TestUserPassword = userPassword;
         ContainerImageName = $"test_{GetType().Name.ToLowerInvariant()}:latest";
@@ -130,6 +134,16 @@ public class SshServer : IDisposable
                 runArgs.AddRange(
                     [ "-v", $"{_sshdConfigFilePath}:/etc/ssh/sshd_config.d/10-custom.conf:z" ]
                 );
+            }
+            if (extraFiles is not null)
+            {
+                foreach (var extraFile in extraFiles)
+                {
+                    string path = Path.GetTempFileName();
+                    File.WriteAllText(path, extraFile.Value);
+                    _extraFilePaths.Add(path);
+                    runArgs.AddRange([ "-v", $"{path}:{extraFile.Key}:z" ]);
+                }
             }
             _containerId = LastWord(Run("podman", ["run", ..runArgs, ContainerImageName]));
             var stopwatch = Stopwatch.StartNew();
@@ -291,6 +305,10 @@ public class SshServer : IDisposable
             if (_sshdConfigFilePath != null)
             {
                 File.Delete(_sshdConfigFilePath);
+            }
+            foreach (string extraFilePath in _extraFilePaths)
+            {
+                File.Delete(extraFilePath);
             }
             if (_containerId != null)
             {
@@ -520,6 +538,35 @@ public class NoneAuthSshServer : SshServer
 
 [CollectionDefinition(nameof(NoneAuthSshServerCollection))]
 public class NoneAuthSshServerCollection : ICollectionFixture<NoneAuthSshServer>
+{
+    // This class has no code, and is never created. Its purpose is simply
+    // to be the place to apply [CollectionDefinition] and all the
+    // ICollectionFixture<> interfaces.
+}
+
+public class BannerSshServer : SshServer
+{
+    public const string BannerFilePath = "/etc/ssh/test_banner";
+
+    public const string BannerMessage =
+        """
+        Authorized use only.
+        Second line of the banner.
+        """;
+
+    public const string Config =
+        $"""
+        Banner {BannerFilePath}
+        """;
+
+    public BannerSshServer(IMessageSink messageSink) :
+        base(Config, messageSink,
+            extraFiles: new Dictionary<string, string>() { [BannerFilePath] = BannerMessage })
+    { }
+}
+
+[CollectionDefinition(nameof(BannerSshServerCollection))]
+public class BannerSshServerCollection : ICollectionFixture<BannerSshServer>
 {
     // This class has no code, and is never created. Its purpose is simply
     // to be the place to apply [CollectionDefinition] and all the

--- a/test/Tmds.Ssh.Tests/SshServer.cs
+++ b/test/Tmds.Ssh.Tests/SshServer.cs
@@ -86,7 +86,6 @@ public class SshServer : IDisposable
     private readonly string _krbConfigFilePath;
     private readonly string _sshConfigFilePath;
     private readonly string? _sshdConfigFilePath;
-    private readonly List<string> _extraFilePaths = new();
     private readonly IMessageSink _messageSink;
     private bool _useDockerInstead;
 
@@ -99,10 +98,7 @@ public class SshServer : IDisposable
         _messageSink.OnMessage(new Xunit.v3.DiagnosticMessage(message));
     }
 
-    /// <param name="extraFiles">Files to mount in the container, keyed by their path in the container.
-    /// Needed for sshd options that take a file path, like 'Banner'.</param>
-    protected SshServer(string? sshdConfig, IMessageSink messageSink, string userPassword = "secret",
-        IReadOnlyDictionary<string, string>? extraFiles = null)
+    protected SshServer(string? sshdConfig, IMessageSink messageSink, string userPassword = "secret")
     {
         TestUserPassword = userPassword;
         ContainerImageName = $"test_{GetType().Name.ToLowerInvariant()}:latest";
@@ -134,16 +130,6 @@ public class SshServer : IDisposable
                 runArgs.AddRange(
                     [ "-v", $"{_sshdConfigFilePath}:/etc/ssh/sshd_config.d/10-custom.conf:z" ]
                 );
-            }
-            if (extraFiles is not null)
-            {
-                foreach (var extraFile in extraFiles)
-                {
-                    string path = Path.GetTempFileName();
-                    File.WriteAllText(path, extraFile.Value);
-                    _extraFilePaths.Add(path);
-                    runArgs.AddRange([ "-v", $"{path}:{extraFile.Key}:z" ]);
-                }
             }
             _containerId = LastWord(Run("podman", ["run", ..runArgs, ContainerImageName]));
             var stopwatch = Stopwatch.StartNew();
@@ -305,10 +291,6 @@ public class SshServer : IDisposable
             if (_sshdConfigFilePath != null)
             {
                 File.Delete(_sshdConfigFilePath);
-            }
-            foreach (string extraFilePath in _extraFilePaths)
-            {
-                File.Delete(extraFilePath);
             }
             if (_containerId != null)
             {
@@ -538,35 +520,6 @@ public class NoneAuthSshServer : SshServer
 
 [CollectionDefinition(nameof(NoneAuthSshServerCollection))]
 public class NoneAuthSshServerCollection : ICollectionFixture<NoneAuthSshServer>
-{
-    // This class has no code, and is never created. Its purpose is simply
-    // to be the place to apply [CollectionDefinition] and all the
-    // ICollectionFixture<> interfaces.
-}
-
-public class BannerSshServer : SshServer
-{
-    public const string BannerFilePath = "/etc/ssh/test_banner";
-
-    public const string BannerMessage =
-        """
-        Authorized use only.
-        Second line of the banner.
-        """;
-
-    public const string Config =
-        $"""
-        Banner {BannerFilePath}
-        """;
-
-    public BannerSshServer(IMessageSink messageSink) :
-        base(Config, messageSink,
-            extraFiles: new Dictionary<string, string>() { [BannerFilePath] = BannerMessage })
-    { }
-}
-
-[CollectionDefinition(nameof(BannerSshServerCollection))]
-public class BannerSshServerCollection : ICollectionFixture<BannerSshServer>
 {
     // This class has no code, and is never created. Its purpose is simply
     // to be the place to apply [CollectionDefinition] and all the

--- a/test/Tmds.Ssh.Tests/sshd_container/Dockerfile
+++ b/test/Tmds.Ssh.Tests/sshd_container/Dockerfile
@@ -47,6 +47,10 @@ RUN echo 'PerSourcePenaltyExemptList "0.0.0.0/0,::/0"' > /etc/ssh/sshd_config.d/
 # Accept TEST_ENVVAR.
 RUN echo 'AcceptEnv TEST_ENVVAR' > /etc/ssh/sshd_config.d/99-accept-envvar.conf
 
+# Send a banner during user authentication.
+RUN printf 'Authorized use only.\nSecond line of the banner.\n' > /etc/ssh/test_banner && \
+    echo 'Banner /etc/ssh/test_banner' > /etc/ssh/sshd_config.d/95-banner.conf
+
 # Configure KDC and setup keytab
 COPY krb5.conf /etc/krb5.conf
 COPY kadm5.acl /var/kerberos/krb5kdc/kadm5.acl


### PR DESCRIPTION
`SSH_MSG_USERAUTH_BANNER` packets are currently parsed and discarded. This leaves
applications unable to show server messages sent during authentication. Besides login
notices, some servers use the banner for an action the user must take: Tailscale SSH
check mode sends its browser sign-in URL in a banner and waits for that check to
complete.

This change adds:

- a `BannerMessageHandler` delegate and a `BannerMessageContext` carrying the message
  and `SshConnectionInfo`;
- `BannerMessageHandler` properties on `SshClientSettings` and `SshConfigSettings`,
  propagated through SSH config loading and proxy-jump settings;
- control character escaping in the library: TAB, CR, and LF are kept, other control
  characters are replaced by an octal escape sequence per UTF-8 byte, matching
  OpenSSH's banner output (RFC 4252 §5.4, RFC 4251 §9.2);
- strict payload parsing (the language tag is read and skipped) with guaranteed packet
  disposal.

The handler is synchronous and is invoked before the next authentication packet is
read. When no handler is configured, banners remain ignored, and `MaxBannerPackets`
remains enforced before parsing or invoking user code.

The default test server now sends a banner, so the existing suite also covers
connecting without a handler. A single integration test verifies delivery through the
delegate; unit tests cover parsing and escaping. The guide documents the API, and the
`ssh` and `ssh-cp` example apps write banners to stderr.

The full container-backed test suite passes on net8.0 through net11.0.
